### PR TITLE
Fixing day number in nice-day

### DIFF
--- a/tools/templater.janet
+++ b/tools/templater.janet
@@ -31,7 +31,7 @@
   []
   (let [date (os/date)
         M (months (date :month))
-        D (date :month-day)
+        D (+ (date :month-day) 1)
         Y (date :year)
         HH (date :hours)
         MM (date :minutes)


### PR DESCRIPTION
The day number from os/date is 0-indexed. Adding 1 before formatting so the human-readable date is correct.