### PR TITLE
Fix too-large click areas on home page buttons

### DIFF
--- a/src/css/landing.css
+++ b/src/css/landing.css
@@ -29,9 +29,6 @@
     color: white;
     text-decoration: none;
     font-size: 1.4em;
-}
-
-.carousel div {
     margin: 5px 5px;
     padding: 10px 15px;
     background-color: #ffffff1a;
@@ -39,7 +36,7 @@
     border: solid 1.5px white;
 }
 
-.carousel div:hover {
+.carousel a:hover {
     background-color: #ffffff30;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -40,10 +40,10 @@
         </div>
       </div>
       <div class="carousel">
-        <a href="https://github.com/janet-lang/janet/releases"><div>Releases</div></a>
-        <a href="https://github.com/janet-lang/janet"><div>Source</div></a>
-        <a href="/introduction.html"><div>Documentation</div></a>
-        <a href="/doc.html"><div>Core API</div></a>
+        <a href="https://github.com/janet-lang/janet/releases">Releases</a>
+        <a href="https://github.com/janet-lang/janet">Source</a>
+        <a href="/introduction.html">Documentation</a>
+        <a href="/doc.html">Core API</a>
       </div>
     </div>
     <div class="top-under"></div>


### PR DESCRIPTION
This fixes the behavior where you could click outside the button to activate it, even though the button wasn’t highlighted as it is on hover.

This also simplifies the HTML; the `div` elements are unnecessary.

related to issue #6