### PR TITLE
Fix typos in Modules documentation

### DIFF
--- a/content/docs/modules.mdz
+++ b/content/docs/modules.mdz
@@ -92,7 +92,7 @@ It's mainly useful when @code`path` is a string and you want to further refine t
 @p{@code`path` can also be a function that checks if a module name matches. If the module name
 matches, the function should return a string that will be used as the main identifier for the
 module. Most of the time, this should be the absolute path to the module, but it can be
-any unqiue key that identifies the module such as an absolute url. It is this key that is
+any unique key that identifies the module such as an absolute url. It is this key that is
 used to determine if a module has been loaded already.
 This mechanism lets @code`./mymod` and @code`mymod`
 refer to the same module even though they are different names passed to import.}
@@ -151,11 +151,11 @@ mymod/
     dep2.janet
 ```
 
-With the above structre, @code`init.janet` can import @code`dep1` and
+With the above structure, @code`init.janet` can import @code`dep1` and
 @code`dep2` with relative imports. This is less brittle as the entire
 @code`mymod/` directory can be installed without any chance that @code`dep1`
 and @code`dep2` will overwrite other files, or that @code`init.janet` will
-acidentally import a different file named @code`dep1.janet` or
+accidentally import a different file named @code`dep1.janet` or
 @code`dep2.janet`. @code`mymod` can even be a sub directory in another janet
 source tree and work as expected.
 

--- a/content/docs/modules.mdz
+++ b/content/docs/modules.mdz
@@ -65,7 +65,7 @@ to use to try and find a given module. The entries in @code`module/paths`
 will be checked in order, as it is possible that multiple entries could match.
 If a module name matches a pattern (which
 usually means that some file exists), then we use the corresponding loader in
-@code`module/loaders` to evaluate that file, source code, url, or whatever else
+@code`module/loaders` to evaluate that file, source code, URL, or whatever else
 we want to derive from the module name. The resulting value, usually an environment
 table, is then cached so that it can be reused later without evaluating a module
 twice.
@@ -92,7 +92,7 @@ It's mainly useful when @code`path` is a string and you want to further refine t
 @p{@code`path` can also be a function that checks if a module name matches. If the module name
 matches, the function should return a string that will be used as the main identifier for the
 module. Most of the time, this should be the absolute path to the module, but it can be
-any unique key that identifies the module such as an absolute url. It is this key that is
+any unique key that identifies the module such as an absolute URL. It is this key that is
 used to determine if a module has been loaded already.
 This mechanism lets @code`./mymod` and @code`mymod`
 refer to the same module even though they are different names passed to import.}
@@ -115,7 +115,7 @@ An example from @code`examples/urlloader.janet` in the source repository shows h
 a loader can be a wrapper around curl and @code`dofile` to load source files from HTTP URLs.
 To use it, simply evaluate this file somewhere in your program before you require code from
 a URL. Don't use this as is in production code, as if @code`url` contains spaces in @code`load-url`
-the module will not load correctly. A more robust solution would quote the url, or better yet
+the module will not load correctly. A more robust solution would quote the URL, or better yet
 use @code`os/execute` and write to a temporary file instead of @code`file/popen`.
 
 @codeblock[janet]```

--- a/content/docs/modules.mdz
+++ b/content/docs/modules.mdz
@@ -172,7 +172,7 @@ init.janet
 Writing a module in Janet is mostly about exposing only the public functions
 that you want users of your module to be able to use. All top level functions defined
 via @code`defn`, macros defined @code`defmacro`, constants defined via @code`def`, and
-and vars defined via @code`var` will be exported in your module. To mark a function or
+vars defined via @code`var` will be exported in your module. To mark a function or
 binding as private to your module, you may use @code`defn-` or @code`def-` at the top level.
 You can also add the @code`:private` metadata to the binding.
 


### PR DESCRIPTION
Fixes a few minor typos and misspellings in the Modules documentation.