### PR TITLE
object oriented docs: verbiage tweaks, fix some typos

### DIFF
--- a/content/docs/object_oriented.mdz
+++ b/content/docs/object_oriented.mdz
@@ -3,7 +3,7 @@
  :order 14}
 ---
 
-Although Janet is a primarily functional language, it has support for
+Although Janet is primarily a functional language, it has support for
 Object Oriented programming as well, where objects and classes are
 represented by tables. Object oriented programming can be very useful
 in domains that are less analytical and more about modeling, such as
@@ -13,8 +13,8 @@ a form of Object Oriented programming via prototypical inheritance, which was pi
 and JavaScript. Janet's implementation of Object Oriented programming is
 designed to be simple, terse, flexible, and efficient in that order of priority.
 
-For information on how table prototypes work, see the previous section on
-@link[/docs/prototypes.html][prototypes].
+Please see the @link[/docs/prototypes.html][prototypes section] for more information
+on table prototypes.
 
 For example:
 
@@ -46,9 +46,9 @@ when it is not used in the function body.
 
 ## Factory functions
 
-Rather than costructors, creating objects in Janet can usually be done with
+Rather than constructors, creating objects in Janet can usually be done with
 a factory function. One can wrap the boilerplate of initializing fields and
-setting the table prototype with a single function with a nice interface.
+setting the table prototype using a single function to create a nice interface.
 
 @codeblock[janet]```
 (defn make-car
@@ -70,7 +70,7 @@ to customize.
 
 ## Structs
 
-Structs can be used as objects as well, not just tables. Structs are of limited use, however, because
+In addition to tables, Structs may also be used as objects. Structs are of limited use, however, because
 they do not have prototypes. This means that they cannot implement any form of inheritance. The above example
 would work for the first object @code`Car`, but @code`RedCar` could not inherit from @code`Car`.
 
@@ -102,4 +102,3 @@ Janet allows adding methods to abstract types. The built in abstract type
 
 (:read stdin :line)
 ```
-


### PR DESCRIPTION
- When reading the docs from start to end, the section on prototypes is not before this section.
- small typos / verbiage tweaks