### PR TITLE
Remove unnecessary const in function signature

### DIFF
--- a/content/capi/index.mdz
+++ b/content/capi/index.mdz
@@ -54,7 +54,7 @@ A basic skeleton for a native module in C is below.
 @codeblock[c]```
 #include <janet.h>
 
-static Janet myfun(int32_t argc, const Janet *argv) {
+static Janet myfun(int32_t argc, Janet *argv) {
     janet_fixarity(argc, 0);
     printf("hello from a module!\n");
     return janet_wrap_nil();


### PR DESCRIPTION
The example includes `const` in the function signature of `mymod`. According to [discussions on Gitter](https://gitter.im/janet-language/community?at=5ebf6b4d90f6db31beec8c4e), this is incorrect and is the cause of the warning:

```
warning: initialization of ‘Janet (*)(int32_t,  Janet *)’ {aka ‘union Janet (*)(int,  union Janet *)’} from incompatible pointer type ‘Janet (*)(int32_t,  const Janet *)’ {aka ‘union Janet (*)(int,  const union Janet *)’} [-Wincompatible-pointer-types]
```

This PR updates the signature.