### PR TITLE
Remove references to cook

### DIFF
--- a/content/capi/index.mdz
+++ b/content/capi/index.mdz
@@ -89,7 +89,7 @@ Inside @code`project.janet`:
 ```
 
 Once you have @code`project.janet` written, run @code`jpm build` to build the module.
-If all goes well, cook should have built a file @code`build/mymod.so`. In your repl, you can now
+If all goes well, @code`jpm` should have built a file @code`build/mymod.so`. In your repl, you can now
 import your module and use it.
 
 @codeblock[janet]```

--- a/content/docs/jpm.mdz
+++ b/content/docs/jpm.mdz
@@ -101,9 +101,6 @@ To create your own software in Janet, it is a good idea to understand what
 the @code`project.janet` file is and how it defines rules for building, testing, and
 installing software. The code in
 @code`project.janet` is normal Janet source code that is run in a special environment.
-Functions and macros from the @code`cook` library have been imported, making then
-easier and more natural to use. For example, @code`cook/declare-project` can be referenced
-as simply @code`declare-project`.
 
 A @code`project.janet` file is loaded by @code`jpm` and evaluated to create
 various recipes, or rules. For example, @code`declare-project` creates


### PR DESCRIPTION
There are two references to `cook`. This PR removes those references.