### PR TITLE
Clean up style across documentation

### DIFF
--- a/content/docs/abstract_machine.mdz
+++ b/content/docs/abstract_machine.mdz
@@ -116,9 +116,9 @@ O - Opcode bits
 +----+----+----+----+
 ```)
 
-Eight bits for the opcode leaves 24 bits for the payload, which may or may not
-be utilized.  There are a few instruction variants that divide these payload
-bits.
+Using 8 bits for the opcode leaves 24 bits for the payload, which may or may
+not be utilized.  There are a few instruction variants that divide these
+payload bits.
 
 @ul{@li{0 arg - Used for noops, returning @code`nil`, or other instructions that
         take no arguments. The payload is essentially ignored.}

--- a/content/docs/abstract_machine.mdz
+++ b/content/docs/abstract_machine.mdz
@@ -4,21 +4,20 @@
  :template "docpage.html"
  :order 17}
 ---
-The Janet language is implemented on top of an abstract machine (AM). The compiler
-converts Janet data structures to this bytecode, which can then be efficiently executed
-from inside a C program. To understand Janet bytecode, it is useful to understand
-the abstractions used inside the Janet AM, as well as the C types used to implement these
-features.
+The Janet language is implemented on top of an abstract machine (AM). The
+compiler converts Janet data structures to this bytecode, which can then be
+efficiently executed from inside a C program. To understand Janet bytecode, it
+is useful to understand the abstractions used inside the Janet AM, as well as
+the C types used to implement these features.
 
 ## The stack = the fiber
 
-A Janet fiber is the type used to represent multiple concurrent processes
-in Janet. It is basically a wrapper around the idea of a stack. The stack is
-divided into a number of stack frames (@code[JanetStackFrame *] in C), each of which
-contains information such as the function that created the stack frame,
-the program counter for the stack frame, a pointer to the previous frame,
-and the size of the frame. Each stack frame also is paired with a number of
-registers.
+A Janet fiber is the type used to represent multiple concurrent processes in
+Janet. It is basically a wrapper around the idea of a stack. The stack is
+divided into a number of stack frames (@code[JanetStackFrame *] in C), each of
+which contains information such as the function that created the stack frame,
+the program counter for the stack frame, a pointer to the previous frame, and
+the size of the frame. Each stack frame also is paired with a number registers.
 
 @codeblock(```
 X: Slot
@@ -59,14 +58,14 @@ Frame -2
 Bottom of stack
 ```)
 
-Fibers also have an incomplete stack frame for the next function call on top
-of their stacks. Making a function call involves pushing arguments to this
-temporary stack, and then invoking either the @code`CALL` or @code`TCALL` instructions.
-Arguments for the next function call are pushed via the @code`PUSH`,
-@code`PUSH2`, @code`PUSH3`, and
-@code`PUSHA` instructions. The stack of a fiber will grow as large as needed, although by
-default Janet will limit the maximum size of a fiber's stack.
-The maximum stack size can be modified on a per-fiber basis.
+Fibers also have an incomplete stack frame for the next function call on top of
+their stacks. Making a function call involves pushing arguments to this
+temporary stack, and then invoking either the @code`CALL` or @code`TCALL`
+instructions.  Arguments for the next function call are pushed via the
+@code`PUSH`, @code`PUSH2`, @code`PUSH3`, and @code`PUSHA` instructions. The
+stack of a fiber will grow as large as needed, although by default Janet will
+limit the maximum size of a fiber's stack.  The maximum stack size can be
+modified on a per-fiber basis.
 
 The slots in the stack are exposed as virtual registers to instructions. They
 can hold any Janet value.
@@ -74,35 +73,38 @@ can hold any Janet value.
 ## Closures
 
 All functions in Janet are closures; they combine some bytecode instructions
-with 0 or more environments. In the C source, a closure (hereby the same as
-a function) is represented by the type @code[JanetFunction *]. The bytecode instruction
-part of the function is represented by @code[JanetFuncDef *], and a function environment
-is represented with @code[JanetFuncEnv *].
+with 0 or more environments. In the C source, a closure (hereby the same as a
+function) is represented by the type @code[JanetFunction *]. The bytecode
+instruction part of the function is represented by @code[JanetFuncDef *], and a
+function environment is represented with @code[JanetFuncEnv *].
 
-The function definition part of a function (the 'bytecode' part, @code[JanetFuncDef *]),
-also stores various metadata about the function which is useful for debugging,
-as well as constants referenced by the function.
+The function definition part of a function (the 'bytecode' part,
+@code[JanetFuncDef *]), also stores various metadata about the function which is
+useful for debugging, as well as constants referenced by the function.
 
 ## C functions
 
 Janet uses C functions to bridge to native code. A C function
-(@code[JanetCFunction *] in C) is a C function pointer that can be called like
-a normal Janet closure. From the perspective of the bytecode instruction set, there is no difference
-in invoking a C function and invoking a normal Janet function.
+(@code[JanetCFunction *] in C) is a C function pointer that can be called like a
+normal Janet closure. From the perspective of the bytecode instruction set,
+there is no difference in invoking a C function and invoking a normal Janet
+function.
 
 ## Bytecode format
 
-Janet bytecode operates on an array of identical registers that can hold any Janet value (@code[Janet *] in C). Most instructions
-have a destination register, and 1 or 2 source registers. Registers are simply indices
-into the stack frame, which can be thought of as a constant sized array.
+Janet bytecode operates on an array of identical registers that can hold any
+Janet value (@code[Janet *] in C). Most instructions have a destination
+register, and 1 or 2 source registers. Registers are simply indices into the
+stack frame, which can be thought of as a constant sized array.
 
-Each instruction is a 32-bit integer, meaning that the instruction set is a constant
-width RISC instruction set like MIPS. The opcode of each instruction is the least significant
-byte of the instruction. The highest bit of
-this leading byte is reserved for debugging purpose, so there are 128 possible opcodes encodable
-with this scheme. Not all of these possible opcodes are defined, and undefined
-opcodes will trap the interpreter and emit a debug signal. Note that this means an unknown opcode is still valid bytecode, it will
-just put the interpreter into a debug state when executed.
+Each instruction is a 32-bit integer, meaning that the instruction set is a
+constant width RISC instruction set like MIPS. The opcode of each instruction is
+the least significant byte of the instruction. The highest bit of this leading
+byte is reserved for debugging purpose, so there are 128 possible opcodes
+encodable with this scheme. Not all of these possible opcodes are defined, and
+undefined opcodes will trap the interpreter and emit a debug signal. Note that
+this means an unknown opcode is still valid bytecode, it will just put the
+interpreter into a debug state when executed.
 
 @codeblock(```
 X - Payload bits
@@ -114,46 +116,57 @@ O - Opcode bits
 +----+----+----+----+
 ```)
 
-Eight bits for the opcode leaves 24 bits for the payload, which may or may not be utilized.
-There are a few instruction variants that divide these payload bits.
+Eight bits for the opcode leaves 24 bits for the payload, which may or may not
+be utilized.  There are a few instruction variants that divide these payload
+bits.
 
-@ul{@li{0 arg - Used for noops, returning @code`nil`, or other instructions that take no
-        arguments. The payload is essentially ignored.}
-    @li{1 arg - All payload bits correspond to a single value, usually a signed or unsigned integer.
-        Used for instructions of 1 argument, like returning a value, yielding a
-        value to the parent fiber, or doing a (relative) jump.}
-    @li{2 arg - Payload is split into byte 2 and bytes 3 and 4. The first argument is the 8-bit value from
-        byte 2, and the second argument is the 16-bit value from bytes 3 and 4 (@code[instruction >> 16]). Used for instructions of
-        two arguments, like move, normal function calls, conditionals, etc.}
+@ul{@li{0 arg - Used for noops, returning @code`nil`, or other instructions that
+        take no arguments. The payload is essentially ignored.}
+    @li{1 arg - All payload bits correspond to a single value, usually a signed
+        or unsigned integer.  Used for instructions of 1 argument, like
+        returning a value, yielding a value to the parent fiber, or doing a
+        (relative) jump.}
+    @li{2 arg - Payload is split into byte 2 and bytes 3 and 4. The first
+        argument is the 8-bit value from byte 2, and the second argument is the
+        16-bit value from bytes 3 and 4 (@code[instruction >> 16]). Used for
+        instructions of two arguments, like move, normal function calls,
+        conditionals, etc.}
     @li{3 arg - Bytes 2, 3, and 4 each correspond to an 8-bit argument.
         Used for arithmetic operations, emitting a signal, etc.}}
 
-These instruction variants can be further refined based on the semantics of the arguments.
-Some instructions may treat an argument as a slot index, while other instructions
-will treat the argument as a signed integer literal, an index for a constant, an index
-for an environment, or an unsigned integer. Keeping the bytecode fairly uniform makes
-verification, compilation, and debugging simpler.
+These instruction variants can be further refined based on the semantics of the
+arguments.  Some instructions may treat an argument as a slot index, while other
+instructions will treat the argument as a signed integer literal, an index for a
+constant, an index for an environment, or an unsigned integer. Keeping the
+bytecode fairly uniform makes verification, compilation, and debugging simpler.
 
 ## Instruction reference
 
-A listing of all opcode values can be found in @code`janet.h`. The Janet assembly
-short names can be found in @code`src/core/asm.c`. In this document, we will refer to the instructions
-by their short names as presented to the assembler rather than their numerical values.
+A listing of all opcode values can be found in @code`janet.h`. The Janet
+assembly short names can be found in @code`src/core/asm.c`. In this document,
+we will refer to the instructions by their short names as presented to the
+assembler rather than their numerical values.
 
-Each instruction is also listed with a signature, which are the arguments the instruction
-expects. There are a handful of instruction signatures, which combine the arity and type
-of the instruction. The assembler does not
-do any type-checking per closure, but does prevent jumping to invalid instructions and
+Each instruction is also listed with a signature, which are the arguments the
+instruction expects. There are a handful of instruction signatures, which
+combine the arity and type of the instruction. The assembler does not do any
+type-checking per closure, but does prevent jumping to invalid instructions and
 failure to return or error.
 
 ### Notation
 
-@ul{@li{The '$' prefix indicates that a instruction parameter is acting as a virtual register (slot). If a parameter
-        does not have the '$' suffix in the description, it is acting as some kind
-        of literal (usually an unsigned integer for indexes, and a signed integer for literal integers).}
-    @li{Some operators in the description have the suffix 'i' or 'r'. These indicate that these operators
-        correspond to integers or real numbers only, respectively. All bit-wise operators and bit shifts only work with integers.}
-    @li{The @code[>>>] indicates unsigned right shift, as in Java. Because all integers in Janet are signed, we differentiate the two kinds of right bit shift.}
+@ul{@li{The '$' prefix indicates that a instruction parameter is acting as a
+        virtual register (slot). If a parameter does not have the '$' suffix in
+        the description, it is acting as some kind of literal (usually an
+        unsigned integer for indexes, and a signed integer for literal
+        integers).}
+    @li{Some operators in the description have the suffix 'i' or 'r'. These
+        indicate that these operators correspond to integers or real numbers
+        only, respectively. All bit-wise operators and bit shifts only work with
+        integers.}
+    @li{The @code[>>>] indicates unsigned right shift, as in Java. Because all
+        integers in Janet are signed, we differentiate the two kinds of right
+        bit shift.}
     @li{The 'im' suffix in the instruction name is short for immediate.}}
 
 ### Reference table

--- a/content/docs/abstract_machine.mdz
+++ b/content/docs/abstract_machine.mdz
@@ -6,14 +6,14 @@
 ---
 The Janet language is implemented on top of an abstract machine (AM). The compiler
 converts Janet data structures to this bytecode, which can then be efficiently executed
-from inside a C program. To understand the janet bytecode, it is useful to understand
+from inside a C program. To understand Janet bytecode, it is useful to understand
 the abstractions used inside the Janet AM, as well as the C types used to implement these
 features.
 
-## The Stack = The Fiber
+## The stack = the fiber
 
-A Janet Fiber is the type used to represent multiple concurrent processes
-in janet. It is basically a wrapper around the idea of a stack. The stack is
+A Janet fiber is the type used to represent multiple concurrent processes
+in Janet. It is basically a wrapper around the idea of a stack. The stack is
 divided into a number of stack frames (@code[JanetStackFrame *] in C), each of which
 contains information such as the function that created the stack frame,
 the program counter for the stack frame, a pointer to the previous frame,
@@ -61,18 +61,19 @@ Bottom of stack
 
 Fibers also have an incomplete stack frame for the next function call on top
 of their stacks. Making a function call involves pushing arguments to this
-temporary stack, and then invoking either the CALL or TCALL instructions.
-Arguments for the next function call are pushed via the PUSH, PUSH2, PUSH3, and
-PUSHA instructions. The stack of a fiber will grow as large as needed, although by
-default janet will limit the maximum size of a fiber's stack.
-The maximum stack size can be modified on a per fiber basis.
+temporary stack, and then invoking either the @code`CALL` or @code`TCALL` instructions.
+Arguments for the next function call are pushed via the @code`PUSH`,
+@code`PUSH2`, @code`PUSH3`, and
+@code`PUSHA` instructions. The stack of a fiber will grow as large as needed, although by
+default Janet will limit the maximum size of a fiber's stack.
+The maximum stack size can be modified on a per-fiber basis.
 
 The slots in the stack are exposed as virtual registers to instructions. They
 can hold any Janet value.
 
 ## Closures
 
-All functions in janet are closures; they combine some bytecode instructions
+All functions in Janet are closures; they combine some bytecode instructions
 with 0 or more environments. In the C source, a closure (hereby the same as
 a function) is represented by the type @code[JanetFunction *]. The bytecode instruction
 part of the function is represented by @code[JanetFuncDef *], and a function environment
@@ -82,25 +83,25 @@ The function definition part of a function (the 'bytecode' part, @code[JanetFunc
 also stores various metadata about the function which is useful for debugging,
 as well as constants referenced by the function.
 
-## C Functions
+## C functions
 
 Janet uses C functions to bridge to native code. A C function
 (@code[JanetCFunction *] in C) is a C function pointer that can be called like
-a normal janet closure. From the perspective of the bytecode instruction set, there is no difference
-in invoking a C function and invoking a normal janet function.
+a normal Janet closure. From the perspective of the bytecode instruction set, there is no difference
+in invoking a C function and invoking a normal Janet function.
 
-## Bytecode Format
+## Bytecode format
 
 Janet bytecode operates on an array of identical registers that can hold any Janet value (@code[Janet *] in C). Most instructions
-have a destination register, and 1 or 2 source registers. Registers are simply indexes
+have a destination register, and 1 or 2 source registers. Registers are simply indices
 into the stack frame, which can be thought of as a constant sized array.
 
-Each instruction is a 32 bit integer, meaning that the instruction set is a constant
+Each instruction is a 32-bit integer, meaning that the instruction set is a constant
 width RISC instruction set like MIPS. The opcode of each instruction is the least significant
 byte of the instruction. The highest bit of
 this leading byte is reserved for debugging purpose, so there are 128 possible opcodes encodable
-with this scheme. Not all of these possible opcode are defined, and will trap the interpreter
-and emit a debug signal. Note that this means an unknown opcode is still valid bytecode, it will
+with this scheme. Not all of these possible opcodes are defined, and undefined
+opcodes will trap the interpreter and emit a debug signal. Note that this means an unknown opcode is still valid bytecode, it will
 just put the interpreter into a debug state when executed.
 
 @codeblock(```
@@ -113,30 +114,30 @@ O - Opcode bits
 +----+----+----+----+
 ```)
 
-8 bits for the opcode leaves 24 bits for the payload, which may or may not be utilized.
+Eight bits for the opcode leaves 24 bits for the payload, which may or may not be utilized.
 There are a few instruction variants that divide these payload bits.
 
-@ul{@li{0 arg - Used for noops, returning nil, or other instructions that take no
+@ul{@li{0 arg - Used for noops, returning @code`nil`, or other instructions that take no
         arguments. The payload is essentially ignored.}
     @li{1 arg - All payload bits correspond to a single value, usually a signed or unsigned integer.
         Used for instructions of 1 argument, like returning a value, yielding a
         value to the parent fiber, or doing a (relative) jump.}
-    @li{2 arg - Payload is split into byte 2 and bytes 3 and 4. The first argument is the 8 bit value from
-        byte 2, and the second argument is the 16 bit value from bytes 3 and 4 (@code[instruction >> 16]). Used for instructions of
+    @li{2 arg - Payload is split into byte 2 and bytes 3 and 4. The first argument is the 8-bit value from
+        byte 2, and the second argument is the 16-bit value from bytes 3 and 4 (@code[instruction >> 16]). Used for instructions of
         two arguments, like move, normal function calls, conditionals, etc.}
-    @li{3 arg - Bytes 2, 3, and 4 each correspond to an 8 bit argument.
+    @li{3 arg - Bytes 2, 3, and 4 each correspond to an 8-bit argument.
         Used for arithmetic operations, emitting a signal, etc.}}
 
 These instruction variants can be further refined based on the semantics of the arguments.
 Some instructions may treat an argument as a slot index, while other instructions
-will treat the argument as a signed integer literal, and index for a constant, an index
+will treat the argument as a signed integer literal, an index for a constant, an index
 for an environment, or an unsigned integer. Keeping the bytecode fairly uniform makes
 verification, compilation, and debugging simpler.
 
-## Instruction Reference
+## Instruction reference
 
-A listing of all opcode values can be found in janet.h. The janet assembly
-short names can be found in src/core/asm.c. In this document, we will refer to the instructions
+A listing of all opcode values can be found in @code`janet.h`. The Janet assembly
+short names can be found in @code`src/core/asm.c`. In this document, we will refer to the instructions
 by their short names as presented to the assembler rather than their numerical values.
 
 Each instruction is also listed with a signature, which are the arguments the instruction
@@ -147,14 +148,14 @@ failure to return or error.
 
 ### Notation
 
-@ul{@li{The $ prefix indicates that a instruction parameter is acting as a virtual register (slot). If a parameter
-        does not have the $ suffix in the description, it is acting as some kind
+@ul{@li{The '$' prefix indicates that a instruction parameter is acting as a virtual register (slot). If a parameter
+        does not have the '$' suffix in the description, it is acting as some kind
         of literal (usually an unsigned integer for indexes, and a signed integer for literal integers).}
     @li{Some operators in the description have the suffix 'i' or 'r'. These indicate that these operators
         correspond to integers or real numbers only, respectively. All bit-wise operators and bit shifts only work with integers.}
-    @li{The @code[>>>] indicates unsigned right shift, as in Java. Because all integers in janet are signed, we differentiate the two kinds of right bit shift.}
+    @li{The @code[>>>] indicates unsigned right shift, as in Java. Because all integers in Janet are signed, we differentiate the two kinds of right bit shift.}
     @li{The 'im' suffix in the instruction name is short for immediate.}}
 
-### Reference Table
+### Reference table
 
 @asm-table/gen()

--- a/content/docs/bindings.mdz
+++ b/content/docs/bindings.mdz
@@ -3,8 +3,8 @@
  :order 4}
 ---
 
-Values can be bound to symbols for later use using the keyword @code[def]. Using undefined
-symbols will raise an error.
+Values can be bound to symbols for later use using the keyword @code[def]. Using
+undefined symbols will raise an error.
 
 @codeblock[janet](```
 (def a 100)
@@ -13,10 +13,11 @@ symbols will raise an error.
 (def d (- c 100))
 ```)
 
-Bindings created with @code`def` have lexical scoping. Additionally, bindings created with @code`def` are immutable; they
-cannot be changed after definition. For mutable bindings, like variables in other programming
-languages, use the @code[var] keyword. The assignment special form @code[set] can then be used to update
-a var.
+Bindings created with @code`def` have lexical scoping. Additionally, bindings
+created with @code`def` are immutable; they cannot be changed after definition.
+For mutable bindings, like variables in other programming languages, use the
+@code[var] keyword. The assignment special form @code[set] can then be used to
+update a var.
 
 @codeblock[janet](```
 (def a 100)
@@ -26,9 +27,10 @@ a var.
 (print myvar)
 ```)
 
-In the global scope, you can use the @code[:private] option on a def or var to prevent it from
-being exported to code that imports your current module. You can also add documentation to
-a function by passing a string to the @code`def` or @code`var` command.
+In the global scope, you can use the @code[:private] option on a def or var to
+prevent it from being exported to code that imports your current module. You can
+also add documentation to a function by passing a string to the @code`def` or
+@code`var` command.
 
 @codeblock[janet](```
 (def mydef :private "This will have private scope. My doc here." 123)
@@ -37,14 +39,15 @@ a function by passing a string to the @code`def` or @code`var` command.
 
 ### Scopes
 
-Defs and vars (collectively known as bindings) live inside what is called a scope. A scope is
-simply where the bindings are valid. If a binding is referenced outside of its scope, the compiler
-will throw an error. Scopes are useful for organizing your bindings and they can expand your programs.
-There are two main ways to create a scope in Janet.
+Defs and vars (collectively known as bindings) live inside what is called a
+scope. A scope is simply where the bindings are valid. If a binding is
+referenced outside of its scope, the compiler will throw an error. Scopes are
+useful for organizing your bindings and they can expand your programs.  There
+are two main ways to create a scope in Janet.
 
-The first is to use the @code[do] special form. @code[do] executes a series of statements in a scope
-and evaluates to the last statement. Bindings created inside the form do not escape outside
-of its scope.
+The first is to use the @code[do] special form. @code[do] executes a series of
+statements in a scope and evaluates to the last statement. Bindings created
+inside the form do not escape outside of its scope.
 
 @codeblock[janet](```
 (def a :outera)
@@ -60,17 +63,18 @@ b # -> compile error: "unknown symbol \"b\""
 c # -> compile error: "unknown symbol \"c\""
 ```)
 
-Any attempt to reference the bindings from the @code`do` form after it has finished
-executing will fail. Also notice that defining @code[a] inside the @code`do` form did not
-overwrite the original definition of @code[a] for the global scope.
+Any attempt to reference the bindings from the @code`do` form after it has
+finished executing will fail. Also notice that defining @code[a] inside the
+@code`do` form did not overwrite the original definition of @code[a] for the
+global scope.
 
-The second way to create a scope is to create a closure.
-The @code[fn] special form also introduces a scope just like
-the @code[do] special form.
+The second way to create a scope is to create a closure.  The @code[fn] special
+form also introduces a scope just like the @code[do] special form.
 
-There is another built in macro, @code[let], that does multiple @code`def`s at once, and then introduces a scope.
-@code[let] is a wrapper around a combination of @code`def`s and @code`do`s, and is the most "functional" way of
-creating bindings.
+There is another built in macro, @code[let], that does multiple @code`def`s at
+once, and then introduces a scope.  @code[let] is a wrapper around a combination
+of @code`def`s and @code`do`s, and is the most "functional" way of creating
+bindings.
 
 @codeblock[janet](```
 (let [a 1
@@ -79,6 +83,6 @@ creating bindings.
   (+ a b c)) # -> 6
 ```)
 
-The above is equivalent to the example using @code[do] and @code[def].
-This is the preferable form in most cases. That said,
-using @code`do` with multiple @code`def`s is fine as well.
+The above is equivalent to the example using @code[do] and @code[def].  This is
+the preferable form in most cases. That said, using @code`do` with multiple
+@code`def`s is fine as well.

--- a/content/docs/bindings.mdz
+++ b/content/docs/bindings.mdz
@@ -13,7 +13,7 @@ symbols will raise an error.
 (def d (- c 100))
 ```)
 
-Bindings created with def have lexical scoping. Also, bindings created with def are immutable; they
+Bindings created with @code`def` have lexical scoping. Additionally, bindings created with @code`def` are immutable; they
 cannot be changed after definition. For mutable bindings, like variables in other programming
 languages, use the @code[var] keyword. The assignment special form @code[set] can then be used to update
 a var.
@@ -28,7 +28,7 @@ a var.
 
 In the global scope, you can use the @code[:private] option on a def or var to prevent it from
 being exported to code that imports your current module. You can also add documentation to
-a function by passing a string to the def or var command.
+a function by passing a string to the @code`def` or @code`var` command.
 
 @codeblock[janet](```
 (def mydef :private "This will have private scope. My doc here." 123)
@@ -60,16 +60,16 @@ b # -> compile error: "unknown symbol \"b\""
 c # -> compile error: "unknown symbol \"c\""
 ```)
 
-Any attempt to reference the bindings from the do form after it has finished
-executing will fail. Also notice that defining @code[a] inside the do form did not
+Any attempt to reference the bindings from the @code`do` form after it has finished
+executing will fail. Also notice that defining @code[a] inside the @code`do` form did not
 overwrite the original definition of @code[a] for the global scope.
 
 The second way to create a scope is to create a closure.
 The @code[fn] special form also introduces a scope just like
 the @code[do] special form.
 
-There is another built in macro, @code[let], that does multiple defs at once, and then introduces a scope.
-@code[let] is a wrapper around a combination of defs and dos, and is the most "functional" way of
+There is another built in macro, @code[let], that does multiple @code`def`s at once, and then introduces a scope.
+@code[let] is a wrapper around a combination of @code`def`s and @code`do`s, and is the most "functional" way of
 creating bindings.
 
 @codeblock[janet](```
@@ -80,6 +80,5 @@ creating bindings.
 ```)
 
 The above is equivalent to the example using @code[do] and @code[def].
-This is the preferable form in most cases,
-but using do with multiple defs is fine as well.
-
+This is the preferable form in most cases. That said,
+using @code`do` with multiple @code`def`s is fine as well.

--- a/content/docs/data_structures/arrays.mdz
+++ b/content/docs/data_structures/arrays.mdz
@@ -8,13 +8,13 @@ a sequence of other values, indexed from 0. Arrays are also mutable, meaning
 that values can be added or removed in place. Many functions in the Janet core
 library will also create arrays, such as @code`map`, @code`filter`, and @code`interpose`.
 
-## Array Length
+## Array length
 
 The length of an array is the number of elements in the array. The last element
-of the array is therefor at index length - 1. To get the length of an array, use
+of the array is therefore at index length - 1. To get the length of an array, use
 the @code[(length x)] function.
 
-## Creating Arrays
+## Creating arrays
 
 There are many ways to create arrays in Janet, but the easiest is
 the array literal.
@@ -25,11 +25,10 @@ the array literal.
 ```)
 
 An array literal begins with an at symbol, @code[@], followed by
-square brackets or parentheses with 0 or more
-values inside.
+square brackets or parentheses with 0 or more values inside.
 
 To create an empty array that you will fill later,
-use the `(array/new capacity)` function. This creates an array with a reserved
+use the @code`(array/new capacity)` function. This creates an array with a reserved
 capacity for a number of elements. This means that appending
 elements to the array will not re-allocate the memory in the array. Using
 an empty array literal would not pre-allocate any space, so the resulting
@@ -48,10 +47,10 @@ arr # -> @[:one :two :three :four]
 ## Getting values
 
 Arrays are not of much use without being able to get and set values inside
-them. To get values from an array, use the `in` or `get` function.  `in`
-will require an index within bounds and will throw an error otherwise. `get`
+them. To get values from an array, use the @code`in` or @code`get` function. @code`in`
+will require an index within bounds and will throw an error otherwise. @code`get`
 requires an index and an optional default value. If the index is out of
-bounds it will return `nil` or the given default value.
+bounds it will return @code`nil` or the given default value.
 
 @codeblock[janet](```
 (def arr @[:a :b :c :d])
@@ -61,7 +60,7 @@ bounds it will return `nil` or the given default value.
 (get arr 100 :default) # -> :default
 ```)
 
-Instead of `in` you can also use the array as a function with the index as an
+Instead of @code`in` you can also use the array as a function with the index as an
 argument or call the index as a function with the array as the first argument.
 
 @codeblock[janet](```
@@ -69,15 +68,15 @@ argument or call the index as a function with the array as the first argument.
 (0 arr) # -> :a
 ```)
 
-Note that a non-integer key will throw an error when using `in`.
+Note that a non-integer key will throw an error when using @code`in`.
 
 ## Setting values
 
-To set values in an array, use either the `put` function or the `set` special.
-The put function is a function that allows putting values in any associative
+To set values in an array, use either the @code`put` function or the @code`set` special.
+The @code`put` function is a function that allows putting values in any associative
 data structure. This means that it can associate keys with values for
 arrays, tables, and buffers. If an index is given that is past the
-end of the array, the array is first padded with nils so that it is large
+end of the array, the array is first padded with @code`nil`s so that it is large
 enough to accommodate the new element.
 
 @codeblock[janet](```
@@ -89,12 +88,12 @@ enough to accommodate the new element.
 arr # -> @[:hi nil :hello]
 ```)
 
-The syntax for the set special is slightly different, as it is
+The syntax for the @code`set` special is slightly different, as it is
 meant to mirror the syntax for getting an element out of a data structure.
 Another difference is that while `put` returns the data structure, `set` evaluates
 to the new value.
 
-## Using an Array as a Stack
+## Using an array as a stack
 
 Arrays can also be used for implementing efficient stacks. The
 Janet core library provides three functions that can be used
@@ -111,18 +110,18 @@ Appends a value to the end of the array and returns the array.
 ### @code[(array/pop stack)]
 
 Removes the last value from stack and returns it. If the array
-is empty, returns nil.
+is empty, returns @code'nil`.
 
 ### @code[(array/peek stack)]
 
 Returns the last element in stack but does not remove it. Returns
-nil if the stack is empty.
+@code`nil` if the stack is empty.
 
 ## More array functions
 
 There are several more functions in the @code[array/] namespace
 and many more functions that create or manipulate arrays in the core
-library. A short list of the author's favorite are below:
+library. A short list of the author's favorites are below:
 
 @ul{@li{@code[array/slice]}
     @li{@code[map]}

--- a/content/docs/data_structures/arrays.mdz
+++ b/content/docs/data_structures/arrays.mdz
@@ -3,36 +3,36 @@
  :order 2}
 ---
 
-Arrays are a fundamental datatype in Janet. Arrays are values that contain
-a sequence of other values, indexed from 0. Arrays are also mutable, meaning
-that values can be added or removed in place. Many functions in the Janet core
-library will also create arrays, such as @code`map`, @code`filter`, and @code`interpose`.
+Arrays are a fundamental datatype in Janet. Arrays are values that contain a
+sequence of other values, indexed from 0. Arrays are also mutable, meaning that
+values can be added or removed in place. Many functions in the Janet core
+library will also create arrays, such as @code`map`, @code`filter`, and
+@code`interpose`.
 
 ## Array length
 
 The length of an array is the number of elements in the array. The last element
-of the array is therefore at index length - 1. To get the length of an array, use
-the @code[(length x)] function.
+of the array is therefore at index length - 1. To get the length of an array,
+use the @code[(length x)] function.
 
 ## Creating arrays
 
-There are many ways to create arrays in Janet, but the easiest is
-the array literal.
+There are many ways to create arrays in Janet, but the easiest is the array
+literal.
 
 @codeblock[janet](```
 (def my-array @[1 2 3 "four"])
 (def my-array2 @(1 2 3 "four"))
 ```)
 
-An array literal begins with an at symbol, @code[@], followed by
-square brackets or parentheses with 0 or more values inside.
+An array literal begins with an at symbol, @code[@], followed by square
+brackets or parentheses with 0 or more values inside.
 
-To create an empty array that you will fill later,
-use the @code`(array/new capacity)` function. This creates an array with a reserved
-capacity for a number of elements. This means that appending
-elements to the array will not re-allocate the memory in the array. Using
-an empty array literal would not pre-allocate any space, so the resulting
-operation would be less efficient.
+To create an empty array that you will fill later, use the @code`(array/new
+capacity)` function. This creates an array with a reserved capacity for a
+number of elements. This means that appending elements to the array will not
+re-allocate the memory in the array. Using an empty array literal would not
+pre-allocate any space, so the resulting operation would be less efficient.
 
 @codeblock[janet](```
 (def arr (array/new 4))
@@ -47,10 +47,10 @@ arr # -> @[:one :two :three :four]
 ## Getting values
 
 Arrays are not of much use without being able to get and set values inside
-them. To get values from an array, use the @code`in` or @code`get` function. @code`in`
-will require an index within bounds and will throw an error otherwise. @code`get`
-requires an index and an optional default value. If the index is out of
-bounds it will return @code`nil` or the given default value.
+them. To get values from an array, use the @code`in` or @code`get` function.
+@code`in` will require an index within bounds and will throw an error
+otherwise. @code`get` requires an index and an optional default value. If the
+index is out of bounds it will return @code`nil` or the given default value.
 
 @codeblock[janet](```
 (def arr @[:a :b :c :d])
@@ -60,8 +60,9 @@ bounds it will return @code`nil` or the given default value.
 (get arr 100 :default) # -> :default
 ```)
 
-Instead of @code`in` you can also use the array as a function with the index as an
-argument or call the index as a function with the array as the first argument.
+Instead of @code`in` you can also use the array as a function with the index as
+an argument or call the index as a function with the array as the first
+argument.
 
 @codeblock[janet](```
 (arr 2) # -> :c
@@ -72,12 +73,12 @@ Note that a non-integer key will throw an error when using @code`in`.
 
 ## Setting values
 
-To set values in an array, use either the @code`put` function or the @code`set` special.
-The @code`put` function is a function that allows putting values in any associative
-data structure. This means that it can associate keys with values for
-arrays, tables, and buffers. If an index is given that is past the
-end of the array, the array is first padded with @code`nil`s so that it is large
-enough to accommodate the new element.
+To set values in an array, use either the @code`put` function or the @code`set`
+special.  The @code`put` function is a function that allows putting values in
+any associative data structure. This means that it can associate keys with
+values for arrays, tables, and buffers. If an index is given that is past the
+end of the array, the array is first padded with @code`nil`s so that it is
+large enough to accommodate the new element.
 
 @codeblock[janet](```
 (def arr @[])
@@ -88,16 +89,15 @@ enough to accommodate the new element.
 arr # -> @[:hi nil :hello]
 ```)
 
-The syntax for the @code`set` special is slightly different, as it is
-meant to mirror the syntax for getting an element out of a data structure.
-Another difference is that while `put` returns the data structure, `set` evaluates
-to the new value.
+The syntax for the @code`set` special is slightly different, as it is meant to
+mirror the syntax for getting an element out of a data structure.  Another
+difference is that while `put` returns the data structure, `set` evaluates to
+the new value.
 
 ## Using an array as a stack
 
-Arrays can also be used for implementing efficient stacks. The
-Janet core library provides three functions that can be used
-to treat an array as a stack.
+Arrays can also be used for implementing efficient stacks. The Janet core
+library provides three functions that can be used to treat an array as a stack.
 
 @ul{@li{@code[(array/push stack value)]}
     @li{@code[(array/pop stack)]}
@@ -109,19 +109,19 @@ Appends a value to the end of the array and returns the array.
 
 ### @code[(array/pop stack)]
 
-Removes the last value from stack and returns it. If the array
-is empty, returns @code'nil`.
+Removes the last value from stack and returns it. If the array is empty,
+returns @code'nil`.
 
 ### @code[(array/peek stack)]
 
-Returns the last element in stack but does not remove it. Returns
-@code`nil` if the stack is empty.
+Returns the last element in stack but does not remove it. Returns @code`nil` if
+the stack is empty.
 
 ## More array functions
 
-There are several more functions in the @code[array/] namespace
-and many more functions that create or manipulate arrays in the core
-library. A short list of the author's favorites are below:
+There are several more functions in the @code[array/] namespace and many more
+functions that create or manipulate arrays in the core library. A short list of
+the author's favorites are below:
 
 @ul{@li{@code[array/slice]}
     @li{@code[map]}

--- a/content/docs/data_structures/buffers.mdz
+++ b/content/docs/data_structures/buffers.mdz
@@ -3,17 +3,17 @@
  :order 2}
 ---
 
-Buffers in Janet are the mutable version of strings. Since strings
-in Janet can hold any sequence of bytes, including zeros, buffers share
-this same property and can be used to hold any arbitrary memory, which
-makes them very simple but versatile data structures. They can be
-used to accumulate small strings into a large string, to implement
-a bitset, or to represent sound or images in a program.
+Buffers in Janet are the mutable version of strings. Since strings in Janet can
+hold any sequence of bytes, including zeros, buffers share this same property
+and can be used to hold any arbitrary memory, which makes them very simple but
+versatile data structures. They can be used to accumulate small strings into a
+large string, to implement a bitset, or to represent sound or images in a
+program.
 
 ## Creating buffers
 
-A buffer literal looks like a string literal, but prefixed with an
-at symbol @code[@].
+A buffer literal looks like a string literal, but prefixed with an at symbol
+@code[@].
 
 @codeblock[janet](```
 (def my-buf @"This is a buffer.")
@@ -30,9 +30,9 @@ at symbol @code[@].
 
 ## Getting bytes from a buffer
 
-To get bytes from a buffer, use the @code[get] function that works
-on all built-in data structures. Bytes in a buffer are indexed from
-0, and each byte is considered an integer from 0 to 255.
+To get bytes from a buffer, use the @code[get] function that works on all
+built-in data structures. Bytes in a buffer are indexed from 0, and each byte is
+considered an integer from 0 to 255.
 
 @codeblock[janet](```
 (def buf @"abcd")
@@ -49,8 +49,8 @@ on all built-in data structures. Bytes in a buffer are indexed from
  (print b4))
 ```)
 
-One can also use the @code`string/slice` or @code`buffer/slice` functions
-to get sub strings (or sub buffers) from inside any sequence of bytes.
+One can also use the @code`string/slice` or @code`buffer/slice` functions to get
+sub strings (or sub buffers) from inside any sequence of bytes.
 
 @codeblock[janet](```
 (def buf @"abcdefg")
@@ -63,10 +63,10 @@ to get sub strings (or sub buffers) from inside any sequence of bytes.
 
 ## Setting bytes in a buffer
 
-Buffers are mutable, meaning we can add bytes or change bytes in
-an already created buffer. Use the @code`put` function to set individual
-bytes in a buffer at a given byte index. Buffers will be expanded
-as needed if an index out of the range provided.
+Buffers are mutable, meaning we can add bytes or change bytes in an already
+created buffer. Use the @code`put` function to set individual bytes in a buffer
+at a given byte index. Buffers will be expanded as needed if an index out of the
+range provided.
 
 @codeblock[janet](```
 (def b @"")
@@ -82,14 +82,14 @@ The @code[set] special form also works for setting bytes in a buffer.
 (set (b 10) 97) #-> @"a\0\0\0\0\0\0\0\0\0a"
 ```)
 
-The main difference between @code[set] and @code[put] is that @code[set] will return the byte
-value, whereas @code[put] will return the buffer value.
+The main difference between @code[set] and @code[put] is that @code[set] will
+return the byte value, whereas @code[put] will return the buffer value.
 
 ## Pushing bytes to a buffer
 
-There are also many functions to push data into a buffer. Since buffers
-are commonly used to accumulate data, there are a variety of functions
-for pushing data into a buffer.
+There are also many functions to push data into a buffer. Since buffers are
+commonly used to accumulate data, there are a variety of functions for pushing
+data into a buffer.
 
 @ul{@li{@code[buffer/push-byte]}
     @li{@code[buffer/push-word]}

--- a/content/docs/data_structures/buffers.mdz
+++ b/content/docs/data_structures/buffers.mdz
@@ -10,9 +10,9 @@ makes them very simple but versatile data structures. They can be
 used to accumulate small strings into a large string, to implement
 a bitset, or to represent sound or images in a program.
 
-## Creating Buffers
+## Creating buffers
 
-A Buffer literal looks like a string literal, but prefixed with an
+A buffer literal looks like a string literal, but prefixed with an
 at symbol @code[@].
 
 @codeblock[janet](```

--- a/content/docs/data_structures/buffers.mdz
+++ b/content/docs/data_structures/buffers.mdz
@@ -31,7 +31,7 @@ at symbol @code[@].
 ## Getting bytes from a buffer
 
 To get bytes from a buffer, use the @code[get] function that works
-on all builtin data structures. Bytes in a buffer are indexed from
+on all built-in data structures. Bytes in a buffer are indexed from
 0, and each byte is considered an integer from 0 to 255.
 
 @codeblock[janet](```
@@ -49,7 +49,7 @@ on all builtin data structures. Bytes in a buffer are indexed from
  (print b4))
 ```)
 
-One can also use the `string/slice` or `buffer/slice` functions
+One can also use the @code`string/slice` or @code`buffer/slice` functions
 to get sub strings (or sub buffers) from inside any sequence of bytes.
 
 @codeblock[janet](```
@@ -64,9 +64,9 @@ to get sub strings (or sub buffers) from inside any sequence of bytes.
 ## Setting bytes in a buffer
 
 Buffers are mutable, meaning we can add bytes or change bytes in
-an already created buffer. Use the `put` function to set individual
+an already created buffer. Use the @code`put` function to set individual
 bytes in a buffer at a given byte index. Buffers will be expanded
-as needed if an index out of the range is provided.
+as needed if an index out of the range provided.
 
 @codeblock[janet](```
 (def b @"")
@@ -83,7 +83,7 @@ The @code[set] special form also works for setting bytes in a buffer.
 ```)
 
 The main difference between @code[set] and @code[put] is that @code[set] will return the byte
-value, while @code[put] will return the buffer value.
+value, whereas @code[put] will return the buffer value.
 
 ## Pushing bytes to a buffer
 
@@ -95,4 +95,4 @@ for pushing data into a buffer.
     @li{@code[buffer/push-word]}
     @li{@code[buffer/push-string]}}
 
-See the documentation for these functions in the @link[/doc.html#buffer/push-byte][Core API].
+See the documentation for these functions in the @link[/api/buffer.html][Buffer API].

--- a/content/docs/data_structures/index.mdz
+++ b/content/docs/data_structures/index.mdz
@@ -5,8 +5,8 @@
 
 Once you have a handle on functions and the primitive value types, you may be wondering how
 to work with collections of things. Janet has a small number of core data structure types
-that are very versatile. Tables, Structs, Arrays, Tuples, Strings, and Buffers, are the 6 main
-built in data structure types. These data structures can be arranged in a useful table describing
+that are very versatile. Tables, structs, arrays, tuples, strings, and buffers, are the 6 main
+built-in data structure types. These data structures can be arranged in a useful table describing
 their relationship to each other.
 
 @tag[table]{
@@ -18,15 +18,15 @@ their relationship to each other.
 Indexed types are linear lists of elements than can be accessed in constant time with an integer index.
 Indexed types are backed by a single chunk of memory for fast access, and are indexed from 0 as in C.
 Dictionary types associate keys with values. The difference between dictionaries and indexed types
-is that dictionaries are not limited to integer keys. They are backed by a hashtable and also offer
+is that dictionaries are not limited to integer keys. They are backed by a hash table and also offer
 constant time lookup (and insertion for the mutable case).
 Finally, the 'bytes' abstraction is any type that contains a sequence of bytes. A 'bytes' value or byteseq associates
 integer keys (the indices) with integer values between 0 and 255 (the byte values). In this way,
-they behave much like Arrays and Tuples. However, one cannot put non integer values into a byteseq.
+they behave much like arrays and tuples. However, one cannot put non-integer values into a byteseq.
 
 The table below summarizes the big-O complexity of various operations and other information
 on the built-in data structures. All primitive operations on data structures will run in constant
-time regarding the number of items in the data structure.
+time regardless of the number of items in the data structure.
 
 @tag[table]{
     @tr{@th{Data Structure} @th{Access} @th{Insert/Append} @th{Delete} @th{Space Complexity} @th{Mutable}}
@@ -67,7 +67,7 @@ elements at random indices will run in @code[O(n)] time where @code[n] is the nu
 (def my-buffer2 @``This is also mutable``)
 ```)
 
-To read the values in a data structure, use the get function. The first parameter is the data structure
+To read the values in a data structure, use the @code`get` function. The first parameter is the data structure
 itself, and the second parameter is the key. An optional third paramter can be used to specify a default
 if the value is not found.
 
@@ -82,9 +82,9 @@ if the value is not found.
 (get {:a :b} :c :d) # -> :d
 ```
 
-Similar to the `get` function and added in `1.5.0`, the `in` function also get values contained in a data structure
-but will throw errors on bad keys to arrays, tuple, and string-likes. You should prefer `in` going forward as
-it can be used to better detect errors. For tables and structs, `in` behaves identically to `get`.
+Similar to the @code`get` function and added in v1.5.0, the @code`in` function also get values contained in a data structure
+but will throw errors on bad keys to arrays, tuple, and string-likes. You should prefer @code`in` going forward as
+it can be used to better detect errors. For tables and structs, @code`in` behaves identically to @code`get`.
 
 @codeblock[janet]```
 (in @[:a :b :c] 2) # -> :c
@@ -93,7 +93,7 @@ it can be used to better detect errors. For tables and structs, `in` behaves ide
 
 To update a mutable data structure, use the @code[put] function. It takes 3 arguments, the data structure,
 the key, and the value, and returns the data structure. The allowed types keys and values
-depend on what data structure is passed in.
+depend on the data structure passed in.
 
 @codeblock[janet]```
 (put @[] 100 :a)
@@ -101,9 +101,9 @@ depend on what data structure is passed in.
 (put @"" 100 92)
 ```
 
-Note that for Arrays and Buffers, putting an index that is outside the length of the data structure
-will extend the data structure and fill it with nils in the case of the Array,
-or 0s in the case of the Buffer.
+Note that for arrays and buffers, putting an index that is outside the length of the data structure
+will extend the data structure and fill it with @code`nil`s in the case of the array,
+or @code`0`s in the case of the buffer.
 
 The last generic function for all data structures is the @code[length] function. This returns the number of
 values in a data structure (the number of keys in a dictionary type).

--- a/content/docs/data_structures/index.mdz
+++ b/content/docs/data_structures/index.mdz
@@ -3,11 +3,12 @@
  :order 11}
 ---
 
-Once you have a handle on functions and the primitive value types, you may be wondering how
-to work with collections of things. Janet has a small number of core data structure types
-that are very versatile. Tables, structs, arrays, tuples, strings, and buffers, are the 6 main
-built-in data structure types. These data structures can be arranged in a useful table describing
-their relationship to each other.
+Once you have a handle on functions and the primitive value types, you may be
+wondering how to work with collections of things. Janet has a small number of
+core data structure types that are very versatile. Tables, structs, arrays,
+tuples, strings, and buffers, are the 6 main built-in data structure types.
+These data structures can be arranged in a useful table describing their
+relationship to each other.
 
 @tag[table]{
     @tr{@th{Interface} @th{Mutable} @th{Immutable}}
@@ -15,18 +16,21 @@ their relationship to each other.
     @tr{@td{Dictionary} @td{Table} @td{Struct}}
     @tr{@td{Bytes} @td{Buffer} @td{String (Symbol, Keyword)}}}
 
-Indexed types are linear lists of elements than can be accessed in constant time with an integer index.
-Indexed types are backed by a single chunk of memory for fast access, and are indexed from 0 as in C.
-Dictionary types associate keys with values. The difference between dictionaries and indexed types
-is that dictionaries are not limited to integer keys. They are backed by a hash table and also offer
-constant time lookup (and insertion for the mutable case).
-Finally, the 'bytes' abstraction is any type that contains a sequence of bytes. A 'bytes' value or byteseq associates
-integer keys (the indices) with integer values between 0 and 255 (the byte values). In this way,
-they behave much like arrays and tuples. However, one cannot put non-integer values into a byteseq.
+Indexed types are linear lists of elements than can be accessed in constant time
+with an integer index.  Indexed types are backed by a single chunk of memory for
+fast access, and are indexed from 0 as in C.  Dictionary types associate keys
+with values. The difference between dictionaries and indexed types is that
+dictionaries are not limited to integer keys. They are backed by a hash table
+and also offer constant time lookup (and insertion for the mutable case).
+Finally, the 'bytes' abstraction is any type that contains a sequence of bytes.
+A 'bytes' value or byteseq associates integer keys (the indices) with integer
+values between 0 and 255 (the byte values). In this way, they behave much like
+arrays and tuples. However, one cannot put non-integer values into a byteseq.
 
-The table below summarizes the big-O complexity of various operations and other information
-on the built-in data structures. All primitive operations on data structures will run in constant
-time regardless of the number of items in the data structure.
+The table below summarizes the big-O complexity of various operations and other
+information on the built-in data structures. All primitive operations on data
+structures will run in constant time regardless of the number of items in the
+data structure.
 
 @tag[table]{
     @tr{@th{Data Structure} @th{Access} @th{Insert/Append} @th{Delete} @th{Space Complexity} @th{Mutable}}
@@ -38,8 +42,9 @@ time regardless of the number of items in the data structure.
     @tr{@td{String/Keyword/Symbol} @td{-} @td{-} @td{-} @td{O(n)} @td{No}}}
 }
 
-*: Append and delete for an array correspond to @code[array/push] and @code[array/pop]. Removing or inserting
-elements at random indices will run in @code[O(n)] time where @code[n] is the number of elements in the array.
+*: Append and delete for an array correspond to @code[array/push] and
+@code[array/pop]. Removing or inserting elements at random indices will run in
+@code[O(n)] time where @code[n] is the number of elements in the array.
 
 @codeblock[janet](```
 (def mytuple (tuple 1 2 3))
@@ -67,9 +72,10 @@ elements at random indices will run in @code[O(n)] time where @code[n] is the nu
 (def my-buffer2 @``This is also mutable``)
 ```)
 
-To read the values in a data structure, use the @code`get` function. The first parameter is the data structure
-itself, and the second parameter is the key. An optional third paramter can be used to specify a default
-if the value is not found.
+To read the values in a data structure, use the @code`get` function. The first
+parameter is the data structure itself, and the second parameter is the key. An
+optional third paramter can be used to specify a default if the value is not
+found.
 
 @codeblock[janet]```
 (get @{:a 1} :a) # -> 1
@@ -82,18 +88,21 @@ if the value is not found.
 (get {:a :b} :c :d) # -> :d
 ```
 
-Similar to the @code`get` function and added in v1.5.0, the @code`in` function also get values contained in a data structure
-but will throw errors on bad keys to arrays, tuple, and string-likes. You should prefer @code`in` going forward as
-it can be used to better detect errors. For tables and structs, @code`in` behaves identically to @code`get`.
+Similar to the @code`get` function and added in v1.5.0, the @code`in` function
+also get values contained in a data structure but will throw errors on bad keys
+to arrays, tuple, and string-likes. You should prefer @code`in` going forward as
+it can be used to better detect errors. For tables and structs, @code`in`
+behaves identically to @code`get`.
 
 @codeblock[janet]```
 (in @[:a :b :c] 2) # -> :c
 (in @[:a :b :c] 3) # -> raises error
 ```
 
-To update a mutable data structure, use the @code[put] function. It takes 3 arguments, the data structure,
-the key, and the value, and returns the data structure. The allowed types keys and values
-depend on the data structure passed in.
+To update a mutable data structure, use the @code[put] function. It takes 3
+arguments, the data structure, the key, and the value, and returns the data
+structure. The allowed types keys and values depend on the data structure passed
+in.
 
 @codeblock[janet]```
 (put @[] 100 :a)
@@ -101,10 +110,10 @@ depend on the data structure passed in.
 (put @"" 100 92)
 ```
 
-Note that for arrays and buffers, putting an index that is outside the length of the data structure
-will extend the data structure and fill it with @code`nil`s in the case of the array,
-or @code`0`s in the case of the buffer.
+Note that for arrays and buffers, putting an index that is outside the length of
+the data structure will extend the data structure and fill it with @code`nil`s
+in the case of the array, or @code`0`s in the case of the buffer.
 
-The last generic function for all data structures is the @code[length] function. This returns the number of
-values in a data structure (the number of keys in a dictionary type).
-
+The last generic function for all data structures is the @code[length] function.
+This returns the number of values in a data structure (the number of keys in a
+dictionary type).

--- a/content/docs/data_structures/structs.mdz
+++ b/content/docs/data_structures/structs.mdz
@@ -2,10 +2,11 @@
  :template "docpage.html"}
 ---
 
-Structs are immutable data structures that map keys to values. They are semantically similar to
-@link[/docs/data_structures/tables.html][tables], but are immutable. They also can be used as
-keys in tables and other structs, and follow expected equality semantics. Like tables, they
-are backed by an efficient, native hash table.
+Structs are immutable data structures that map keys to values. They are
+semantically similar to @link[/docs/data_structures/tables.html][tables], but
+are immutable. They also can be used as keys in tables and other structs, and
+follow expected equality semantics. Like tables, they are backed by an
+efficient, native hash table.
 
 To create a struct, you may use a struct literal or the @code`struct` function.
 
@@ -21,8 +22,9 @@ To create a struct, you may use a struct literal or the @code`struct` function.
 (= my-struct my-struct2) #-> true
 ```
 
-As with other data structures, you may retrieve values in a struct via the @code`get` function, or
-call the struct as a function. Since structs are immutable, you cannot add key-value pairs
+As with other data structures, you may retrieve values in a struct via the
+@code`get` function, or call the struct as a function. Since structs are
+immutable, you cannot add key-value pairs
 
 @codeblock[janet]```
 (def st {:a 1 :b 2})
@@ -33,8 +35,9 @@ call the struct as a function. Since structs are immutable, you cannot add key-v
 
 ## Converting a table to a struct
 
-A table can be converted to a struct via the @code`table/to-struct` function. This is useful for efficiently
-creating a struct by first incrementally putting key-value pairs in a table.
+A table can be converted to a struct via the @code`table/to-struct` function.
+This is useful for efficiently creating a struct by first incrementally putting
+key-value pairs in a table.
 
 @codeblock[janet]```
 (def accum @{})
@@ -43,11 +46,11 @@ creating a struct by first incrementally putting key-value pairs in a table.
 (def my-struct (table/to-struct accum))
 ```
 
-## Using Structs as keys
+## Using structs as keys
 
-Because a struct is equal to any struct with the same contents, structs make useful keys for
-tables or other structs. For example, we can use structs to represent Cartesian points and
-keep a mapping from points to other values.
+Because a struct is equal to any struct with the same contents, structs make
+useful keys for tables or other structs. For example, we can use structs to
+represent Cartesian points and keep a mapping from points to other values.
 
 @codeblock[janet]```
 (def points @{

--- a/content/docs/data_structures/structs.mdz
+++ b/content/docs/data_structures/structs.mdz
@@ -4,8 +4,8 @@
 
 Structs are immutable data structures that map keys to values. They are semantically similar to
 @link[/docs/data_structures/tables.html][tables], but are immutable. They also can be used as
-keys in tables and other structs, and follow the expected equality semantics. Like tables, they
-are backed by an efficient, native hashtable.
+keys in tables and other structs, and follow expected equality semantics. Like tables, they
+are backed by an efficient, native hash table.
 
 To create a struct, you may use a struct literal or the @code`struct` function.
 
@@ -22,7 +22,7 @@ To create a struct, you may use a struct literal or the @code`struct` function.
 ```
 
 As with other data structures, you may retrieve values in a struct via the @code`get` function, or
-call the struct as a function. Since structs are immutable, you cannot add key value pairs
+call the struct as a function. Since structs are immutable, you cannot add key-value pairs
 
 @codeblock[janet]```
 (def st {:a 1 :b 2})
@@ -31,10 +31,10 @@ call the struct as a function. Since structs are immutable, you cannot add key v
 (st :b) #-> 2
 ```
 
-## Converting a Table to a Struct
+## Converting a table to a struct
 
-A table can be converted to a struct via the @code`table/to-struct` function. This is useful for incrementally
-building up a struct via putting key values pairs in a table.
+A table can be converted to a struct via the @code`table/to-struct` function. This is useful for efficiently
+creating a struct by first incrementally putting key-value pairs in a table.
 
 @codeblock[janet]```
 (def accum @{})
@@ -43,11 +43,11 @@ building up a struct via putting key values pairs in a table.
 (def my-struct (table/to-struct accum))
 ```
 
-## Using Structs as Keys
+## Using Structs as keys
 
-Because structs are equal to any struct with the same contents, they make useful keys for
-tables or other structs. For example, we can use structs to represent cartesian points and
-keep a mapping of from points to other values.
+Because a struct is equal to any struct with the same contents, structs make useful keys for
+tables or other structs. For example, we can use structs to represent Cartesian points and
+keep a mapping from points to other values.
 
 @codeblock[janet]```
 (def points @{

--- a/content/docs/data_structures/tables.mdz
+++ b/content/docs/data_structures/tables.mdz
@@ -4,16 +4,16 @@
 ---
 
 The table is one of the most flexible data structures in Janet and
-is modeled after the associative array, or dictionary. Values are
+is modeled after the associative array or dictionary. Values are
 put into a table with a key, and can be looked up later with the
 same key. Tables are implemented with an underlying open hash table, so
 they are quite fast and cache friendly.
 
-Any Janet value except nil and NaN can either a key or a value in a Janet
+Any Janet value except @code`nil` and @code`NaN` can be a key or a value in a Janet
 table, and a single Janet table can have any mixture of
 types as keys and values.
 
-## Creating Tables
+## Creating tables
 
 The easiest way to create a table is via a table literal.
 
@@ -37,12 +37,12 @@ most cases, a table literal should be preferred.
              '(1 0) @{:another :table}))
 ```)
 
-## Getting and Setting values
+## Getting and setting values
 
 Like other data structures in Janet, values in a table can be retrieved
 with the @code[get] function, and new values in a table can be added via the
-@code[put] function or the @code[set] special. Inserting a value of nil into a table
-removes the key from the table. This means table's cannot contain nil values.
+@code[put] function or the @code[set] special. Inserting a value of @code`nil` into a table
+removes the key from the table. This means tables cannot contain @code`nil` values.
 
 @codeblock[janet](```
 (def t @{})
@@ -64,7 +64,7 @@ removes the key from the table. This means table's cannot contain nil values.
 
 All tables can have a prototype, a parent table that is checked when a
 key is not found in the first table. By default, tables have no prototype.
-Prototypes are a flexible mechanism that, among other uses, can be used to
+Prototypes are a flexible mechanism that, among other things, can be used to
 implement inheritance in Janet. Read more in the @link[/docs/prototypes.html][documentation for prototypes]
 
 ## Useful functions for tables
@@ -88,4 +88,4 @@ is a non-exhaustive list.
     @li{@code[walk]}
     @li{@code[zipcoll]}}
 
-See the @link[/doc.html][Core Api Documentation] for more information on individual functions.
+See the @link[/api/table.html][Table API] documentation for table-specific functions.

--- a/content/docs/data_structures/tables.mdz
+++ b/content/docs/data_structures/tables.mdz
@@ -3,15 +3,14 @@
  :order 3}
 ---
 
-The table is one of the most flexible data structures in Janet and
-is modeled after the associative array or dictionary. Values are
-put into a table with a key, and can be looked up later with the
-same key. Tables are implemented with an underlying open hash table, so
-they are quite fast and cache friendly.
+The table is one of the most flexible data structures in Janet and is modeled
+after the associative array or dictionary. Values are put into a table with a
+key, and can be looked up later with the same key. Tables are implemented with
+an underlying open hash table, so they are quite fast and cache friendly.
 
-Any Janet value except @code`nil` and @code`NaN` can be a key or a value in a Janet
-table, and a single Janet table can have any mixture of
-types as keys and values.
+Any Janet value except @code`nil` and @code`NaN` can be a key or a value in a
+Janet table, and a single Janet table can have any mixture of types as keys and
+values.
 
 ## Creating tables
 
@@ -25,9 +24,9 @@ The easiest way to create a table is via a table literal.
  '(1 0) @{:another :table}})
 ```)
 
-Another way to create a table is via the @code[table] function. This has the advantage
-that @code[table] is an ordinary function that can be passed around like any other. For
-most cases, a table literal should be preferred.
+Another way to create a table is via the @code[table] function. This has the
+advantage that @code[table] is an ordinary function that can be passed around
+like any other. For most cases, a table literal should be preferred.
 
 @codeblock[janet](```
 (def my-tab (table
@@ -39,10 +38,11 @@ most cases, a table literal should be preferred.
 
 ## Getting and setting values
 
-Like other data structures in Janet, values in a table can be retrieved
-with the @code[get] function, and new values in a table can be added via the
-@code[put] function or the @code[set] special. Inserting a value of @code`nil` into a table
-removes the key from the table. This means tables cannot contain @code`nil` values.
+Like other data structures in Janet, values in a table can be retrieved with
+the @code[get] function, and new values in a table can be added via the
+@code[put] function or the @code[set] special. Inserting a value of @code`nil`
+into a table removes the key from the table. This means tables cannot contain
+@code`nil` values.
 
 @codeblock[janet](```
 (def t @{})
@@ -62,10 +62,11 @@ removes the key from the table. This means tables cannot contain @code`nil` valu
 
 ## Prototypes
 
-All tables can have a prototype, a parent table that is checked when a
-key is not found in the first table. By default, tables have no prototype.
-Prototypes are a flexible mechanism that, among other things, can be used to
-implement inheritance in Janet. Read more in the @link[/docs/prototypes.html][documentation for prototypes]
+All tables can have a prototype, a parent table that is checked when a key is
+not found in the first table. By default, tables have no prototype.  Prototypes
+are a flexible mechanism that, among other things, can be used to implement
+inheritance in Janet. Read more in the
+@link[/docs/prototypes.html][documentation for prototypes]
 
 ## Useful functions for tables
 

--- a/content/docs/data_structures/tuples.mdz
+++ b/content/docs/data_structures/tuples.mdz
@@ -4,10 +4,10 @@
 
 Tuples are immutable, sequential types that are similar to arrays. They are
 represented in source code with either parenthesis or brackets surrounding
-their items. Note that Janet differs from traditional Lisps here, which commonly
-use the term "lists" to describe forms wrapped in parenthesis. Like all data
-structures, tuple contents can be retrieved with the @code`get` function and
-their length retrieved with the @code`length` function.
+their items. Note that Janet differs from traditional Lisps here, which
+commonly use the term "lists" to describe forms wrapped in parenthesis. Like
+all data structures, tuple contents can be retrieved with the @code`get`
+function and their length retrieved with the @code`length` function.
 
 The two most common ways to create a tuple are using the literal form with
 bracket characters @code`[]` or calling the @code`tuple` function directly.
@@ -31,8 +31,8 @@ bracket characters @code`[]` or calling the @code`tuple` function directly.
 
 ## As table keys
 
-Tuples can be used as table keys because two tuples with the same
-contents are considered equal:
+Tuples can be used as table keys because two tuples with the same contents are
+considered equal:
 
 @codeblock[janet]```
 (def points @{[0 0] "A"
@@ -48,9 +48,10 @@ contents are considered equal:
 ## Sorting tuples
 
 Tuples can also be used to sort items. When sorting tuples via the @code`<` or
-@code`>` comparators, the first elements are compared first. If those elements are equal, we
-move on to the second element, then the third, and so on. We could use this property of tuples
-to sort all kind of data, or sort one array by the contents of another array.
+@code`>` comparators, the first elements are compared first. If those elements
+are equal, we move on to the second element, then the third, and so on. We
+could use this property of tuples to sort all kind of data, or sort one array
+by the contents of another array.
 
 @codeblock[janet]```
 (def inventory [
@@ -74,21 +75,25 @@ to sort all kind of data, or sort one array by the contents of another array.
 
 ## Bracketed tuples
 
-Under the hood, there are two kinds of tuples: bracketed and non-bracketed. We have seen above
-that bracket tuples are used to create a tuple with @code`[]` characters (ie: a tuple literal).
-The way a tuple literal is interpreted by the compiler is one of the few ways in which bracketed tuples
-and non-bracketed tuples differ:
+Under the hood, there are two kinds of tuples: bracketed and non-bracketed. We
+have seen above that bracket tuples are used to create a tuple with @code`[]`
+characters (ie: a tuple literal).  The way a tuple literal is interpreted by
+the compiler is one of the few ways in which bracketed tuples and non-bracketed
+tuples differ:
 
-@ul{@li{Bracket tuples are interpreted as a tuple constructor rather than a function call by the compiler.}
-    @li{When printed via @code`pp`, bracket tuples are printed with square brackets instead of parentheses.}
-    @li{When passed as an argument to @code`tuple/type`, bracket tuples will returns @code`:brackets` instead of @code`:parens`.}}
+@ul{@li{Bracket tuples are interpreted as a tuple constructor rather than a
+        function call by the compiler.}
+    @li{When printed via @code`pp`, bracket tuples are printed with square
+        brackets instead of parentheses.}
+    @li{When passed as an argument to @code`tuple/type`, bracket tuples will
+        returns @code`:brackets` instead of @code`:parens`.}}
 
-In all other ways, bracketed tuples behave identically to normal tuples. It is not
-recommended to use bracketed tuples for anything outside of macros and tuple
-constructors (ie: tuple literals).
+In all other ways, bracketed tuples behave identically to normal tuples. It is
+not recommended to use bracketed tuples for anything outside of macros and
+tuple constructors (ie: tuple literals).
 
 ## More functions
 
-Most functions in the core library that work on arrays also work on tuples, or have
-an analogous function for tuples. See the @link[/api/tuple.html][Tuple API] for a
-list of functions that operate on tuples.
+Most functions in the core library that work on arrays also work on tuples, or
+have an analogous function for tuples. See the @link[/api/tuple.html][Tuple API]
+for a list of functions that operate on tuples.

--- a/content/docs/data_structures/tuples.mdz
+++ b/content/docs/data_structures/tuples.mdz
@@ -3,13 +3,13 @@
 ---
 
 Tuples are immutable, sequential types that are similar to arrays. They are
-represented in the source code with either parenthesis or brackets surrounding
+represented in source code with either parenthesis or brackets surrounding
 their items. Note that Janet differs from traditional Lisps here, which commonly
 use the term "lists" to describe forms wrapped in parenthesis. Like all data
 structures, tuple contents can be retrieved with the @code`get` function and
 their length retrieved with the @code`length` function.
 
-The two most common ways to create a tuple is using the literal form with
+The two most common ways to create a tuple are using the literal form with
 bracket characters @code`[]` or calling the @code`tuple` function directly.
 
 @codeblock[janet]```
@@ -29,7 +29,7 @@ bracket characters @code`[]` or calling the @code`tuple` function directly.
 (assert (= mytup1 mytup2 mytup3 mytup4)) # true
 ```
 
-## As Table Keys
+## As table keys
 
 Tuples can be used as table keys because two tuples with the same
 contents are considered equal:
@@ -45,12 +45,12 @@ contents are considered equal:
 (get points [8 5])       # nil (ie: not found)
 ```
 
-## Sorting Tuples
+## Sorting tuples
 
-Tuples can also be used to sort items. When sorting tuples via the @code`order<` or
-@code`<` comparators, the first elements are compared first. If those elements are equal, we
+Tuples can also be used to sort items. When sorting tuples via the @code`<` or
+@code`>` comparators, the first elements are compared first. If those elements are equal, we
 move on to the second element, then the third, and so on. We could use this property of tuples
-to sort all sorts of data, or sort one array by the contents of another array.
+to sort all kind of data, or sort one array by the contents of another array.
 
 @codeblock[janet]```
 (def inventory [
@@ -72,23 +72,23 @@ to sort all sorts of data, or sort one array by the contents of another array.
 # flamingo: 23
 ```
 
-## Bracketed Tuples
+## Bracketed tuples
 
-Under the hood there are two kinds of tuples: bracketed and non-bracketed. We have seen above
-that bracket tuples are used to create a tuple constructor with @code`[]` characters (ie: a tuple literal).
-The way a tuple literal is interpreted by the compiler is one of the few ways in which bracket tuples
+Under the hood, there are two kinds of tuples: bracketed and non-bracketed. We have seen above
+that bracket tuples are used to create a tuple with @code`[]` characters (ie: a tuple literal).
+The way a tuple literal is interpreted by the compiler is one of the few ways in which bracketed tuples
 and non-bracketed tuples differ:
 
 @ul{@li{Bracket tuples are interpreted as a tuple constructor rather than a function call by the compiler.}
     @li{When printed via @code`pp`, bracket tuples are printed with square brackets instead of parentheses.}
     @li{When passed as an argument to @code`tuple/type`, bracket tuples will returns @code`:brackets` instead of @code`:parens`.}}
 
-In all other ways, bracket tuples behave identically to normal tuples. It is not
-recommended to use bracket tuples for anything outside of macros and tuple
+In all other ways, bracketed tuples behave identically to normal tuples. It is not
+recommended to use bracketed tuples for anything outside of macros and tuple
 constructors (ie: tuple literals).
 
-## More Functions
+## More functions
 
 Most functions in the core library that work on arrays also work on tuples, or have
-an analogous function for tuples. See the @link[/doc.html#tuple][tuple section] in
-the Core Library API for a comprehensive list of functions that operate on tuples.
+an analogous function for tuples. See the @link[/api/tuple.html][Tuple API] for a
+list of functions that operate on tuples.

--- a/content/docs/destructuring.mdz
+++ b/content/docs/destructuring.mdz
@@ -4,10 +4,9 @@
 ---
 
 Janet uses the @code[get] function to retrieve values from inside data
-structures. In many cases, however, you do not need the @code[get]
-function at all. Janet supports destructuring, which means both the
-@code[def] and @code[var] special forms can extract values from inside
-structures themselves.
+structures. In many cases, however, you do not need the @code[get] function at
+all. Janet supports destructuring, which means both the @code[def] and
+@code[var] special forms can extract values from inside structures themselves.
 
 @codeblock[janet](```
 # Without destructuring, we might do
@@ -28,6 +27,7 @@ structures themselves.
 (print person-age)  # Prints 77
 ```)
 
-Destructuring works in many places in Janet, including @code`let` expressions, function
-parameters, and @code`var`. It is a useful shorthand for extracting values from data structures and
-is the recommended way to get values out of small structures.
+Destructuring works in many places in Janet, including @code`let` expressions,
+function parameters, and @code`var`. It is a useful shorthand for extracting
+values from data structures and is the recommended way to get values out of
+small structures.

--- a/content/docs/fibers/dynamic_bindings.mdz
+++ b/content/docs/fibers/dynamic_bindings.mdz
@@ -6,11 +6,11 @@ There are situations where the programmer would like to thread a parameter throu
 multiple function calls, without passing that argument to every function explicitly.
 This can make code more concise, easier to read, and easier to extend. Dynamic bindings
 are a mechanism that provide this in a safe and easy to use way.
-This is in contrast to lexically scoped bindings, which are usually superior to
-dynamically scoped bindings in terms of clarity, composability, and
+This is in contrast to lexically-scoped bindings, which are usually superior to
+dynamically-scoped bindings in terms of clarity, composability, and
 performance. However, dynamic scoping can be used to great effect for implicit
 contexts, configuration, and testing. Janet supports dynamic scoping as of
-version 0.5.0 on a per fiber basis @html[&mdash;] each fiber contains an
+version 0.5.0 on a per-fiber basis @html[&mdash;] each fiber contains an
 environment table that can be queried for values. Using table prototypes, we
 can easily emulate dynamic scoping.
 
@@ -25,7 +25,7 @@ To set a dynamic binding, use the @code`setdyn` function.
 
 ## Getting a value
 
-To get a dynamically scoped binding, use the @code`dyn` function.
+To get a dynamically-scoped binding, use the @code`dyn` function.
 
 @codeblock[janet]```
 (dyn :my-var) # returns nil
@@ -33,7 +33,7 @@ To get a dynamically scoped binding, use the @code`dyn` function.
 (dyn :my-var) # returns 10
 ```
 
-## Creating a Dynamic Scope
+## Creating a dynamic scope
 
 Now that we can get and set dynamic bindings, we need to know how to create
 dynamic scopes themselves. To do this, we can create a new fiber and then use
@@ -66,7 +66,8 @@ print function @code`pp`.
 (pp [1 2 3]) # prints "[1 2 3]"
 ```
 
-This is verbose so the core library provides a macro, @code`with-dyns`, that makes it much clearer in the common case.
+This is verbose so the core library provides a macro, @code`with-dyns`, that
+makes it much clearer in the common case.
 
 @codeblock[janet]```
 (pp [1 2 3]) # prints "[1 2 3]"
@@ -76,14 +77,17 @@ This is verbose so the core library provides a macro, @code`with-dyns`, that mak
 (pp [1 2 3]) # prints "[1 2 3]"
 ```
 
-## When to Use Dynamic Bindings
+## When to use dynamic bindings
 
-Dynamic bindings should be used when you want to pass around an implicit, global context, especially when you want to
-automatically reset the context if an error is raised. Since a dynamic binding is tied to the current fiber, when a fiber
-exits the context is automatically unset. This is much easier and often more efficient than manually trying to detect errors
-and unset context. Consider the following example code, written once with a global var and once with a dynamic binding.
+Dynamic bindings should be used when you want to pass around an implicit, global
+context, especially when you want to automatically reset the context if an error
+is raised. Since a dynamic binding is tied to the current fiber, when a fiber
+exits the context is automatically unset. This is much easier and often more
+efficient than manually trying to detect errors and unset context. Consider the
+following example code, written once with a global var and once with a dynamic
+binding.
 
-### Using a Global Var
+### Using a global var
 
 @codeblock[janet]```
 (var *my-binding* 10)
@@ -102,10 +106,12 @@ and unset context. Consider the following example code, written once with a glob
  (set *my-binding* oldx))
 ```
 
-This example is a bit verbose, but most importantly it fails to reset @code`*my-binding*` if an error is thrown. We could fix
-this with a @code`try`, but even that may have subtle bugs if the fiber yields but is never resumed. However, there is a better solution with dynamic bindings.
+This example is a bit verbose, but most importantly it fails to reset
+@code`*my-binding*` if an error is thrown. We could fix this with a @code`try`,
+but even that may have subtle bugs if the fiber yields but is never resumed.
+However, there is a better solution with dynamic bindings.
 
-### Using a Dynamic Binding
+### Using a dynamic binding
 
 @codeblock[janet]```
 (defn may-error
@@ -119,9 +125,10 @@ this with a @code`try`, but even that may have subtle bugs if the fiber yields b
    (may-error)))
 ```
 
-This looks much cleaner, thanks to a macro, but is also correct in handling errors and any other signal that a fiber may emit.
-In general, prefer dynamic bindings over global vars. Global vars are mainly
-useful for scripts or truly program global configuration.
+This looks much cleaner, thanks to a macro, but is also correct in handling
+errors and any other signal that a fiber may emit.  In general, prefer dynamic
+bindings over global vars. Global vars are mainly useful for scripts or truly
+program-global configuration.
 
 ## Advanced use cases
 
@@ -131,9 +138,10 @@ in the fiber, so it serves as a place to store implicit context. During compilat
 table also contains top level bindings available for use, and is what is returned
 from a @code`(require ...)` expression.
 
-With this in mind, there is no requirement that the first argument to @code`(setdyn name value)` and
-@code`(dyn name)` are keywords. These functions can be used to quickly put values into and
-get values from the current environment. As such, they can be used for getting metadata for a given symbol.
+With this in mind, there is no requirement that the first argument to
+@code`(setdyn name value)` and @code`(dyn name)` be keywords. These functions
+can be used to quickly put values in and get values from the current
+environment. As such, these can be used for getting metadata for a given symbol.
 
 @codeblock[janet]```
 (dyn 'pp) # -> prints all metadata in the current environment for pp.
@@ -154,5 +162,3 @@ that are otherwise not possible in a macro.
     (setdyn name @{:value (math/random)}))
   nil)
 ```
-
-

--- a/content/docs/fibers/dynamic_bindings.mdz
+++ b/content/docs/fibers/dynamic_bindings.mdz
@@ -2,17 +2,17 @@
  :template "docpage.html"}
 ---
 
-There are situations where the programmer would like to thread a parameter through
-multiple function calls, without passing that argument to every function explicitly.
-This can make code more concise, easier to read, and easier to extend. Dynamic bindings
-are a mechanism that provide this in a safe and easy to use way.
-This is in contrast to lexically-scoped bindings, which are usually superior to
-dynamically-scoped bindings in terms of clarity, composability, and
+There are situations where the programmer would like to thread a parameter
+through multiple function calls, without passing that argument to every function
+explicitly.  This can make code more concise, easier to read, and easier to
+extend. Dynamic bindings are a mechanism that provide this in a safe and easy to
+use way.  This is in contrast to lexically-scoped bindings, which are usually
+superior to dynamically-scoped bindings in terms of clarity, composability, and
 performance. However, dynamic scoping can be used to great effect for implicit
 contexts, configuration, and testing. Janet supports dynamic scoping as of
 version 0.5.0 on a per-fiber basis @html[&mdash;] each fiber contains an
-environment table that can be queried for values. Using table prototypes, we
-can easily emulate dynamic scoping.
+environment table that can be queried for values. Using table prototypes, we can
+easily emulate dynamic scoping.
 
 ## Setting a value
 
@@ -133,10 +133,10 @@ program-global configuration.
 ## Advanced use cases
 
 Dynamic bindings work by a table associated with each fiber, called the fiber
-environment (often "env" for short). This table can be accessed by all functions
-in the fiber, so it serves as a place to store implicit context. During compilation, this
-table also contains top level bindings available for use, and is what is returned
-from a @code`(require ...)` expression.
+environment (often "env" for short). This table can be accessed by all
+functions in the fiber, so it serves as place to store implicit context. During
+compilation, this table also contains top-level bindings available for use, and
+is what is returned from a @code`(require ...)` expression.
 
 With this in mind, there is no requirement that the first argument to
 @code`(setdyn name value)` and @code`(dyn name)` be keywords. These functions
@@ -151,8 +151,8 @@ environment. As such, these can be used for getting metadata for a given symbol.
 (setdyn 'a nil) # -> will remove the binding to 'a in the current environment.
 ```
 
-Macros can modify this table to do things
-that are otherwise not possible in a macro.
+Macros can modify this table to do things that are otherwise not possible in a
+macro.
 
 @codeblock[janet]```
 (defmacro make-defs

--- a/content/docs/fibers/error_handling.mdz
+++ b/content/docs/fibers/error_handling.mdz
@@ -5,10 +5,11 @@
 
 One of the main uses of fibers is to encapsulate and handle errors. Janet offers
 no direct try/catch mechanism like some languages, and instead builds error
-handling on top of fibers. When a function throws an error, Janet creates a signal
-and throws that signal in the current fiber. The signal will be propagated up the
-chain of active fibers until it hits a fiber that is ready to handle the error signal.
-This fiber will trap the signal and return the error from the last call to @code`resume`.
+handling on top of fibers. When a function throws an error, Janet creates a
+signal and throws that signal in the current fiber. The signal will be
+propagated up the chain of active fibers until it hits a fiber that is ready to
+handle the error signal.  This fiber will trap the signal and return the error
+from the last call to @code`resume`.
 
 @codeblock[janet]```
 (defn block
@@ -31,8 +32,8 @@ This fiber will trap the signal and return the error from the last call to @code
  (print "value returned: " res))
 ```
 
-Janet also provides a simple macro @code`try` to make this
-a bit easier in the common case.
+Janet also provides a simple macro @code`try` to make this a bit easier in the
+common case.
 
 @codeblock[janet]```
 (try

--- a/content/docs/fibers/error_handling.mdz
+++ b/content/docs/fibers/error_handling.mdz
@@ -3,9 +3,9 @@
  :template "docpage.html"}
 ---
 
-One of the main uses of Fibers is to encapsulate and handle errors. Janet offers
-no direct mechanism for try/catch like some languages, and instead builds error
-handling on top of Fibers. When some function throws an error, Janet creates a signal
+One of the main uses of fibers is to encapsulate and handle errors. Janet offers
+no direct try/catch mechanism like some languages, and instead builds error
+handling on top of fibers. When a function throws an error, Janet creates a signal
 and throws that signal in the current fiber. The signal will be propagated up the
 chain of active fibers until it hits a fiber that is ready to handle the error signal.
 This fiber will trap the signal and return the error from the last call to @code`resume`.
@@ -18,7 +18,7 @@ This fiber will trap the signal and return the error from the last call to @code
 
 # Pass the :e flag to trap errors (and only errors).
 # All other signals will be propagated up the fiber stack.
-(def f (fiber/new block :e)) 
+(def f (fiber/new block :e))
 
 # Get result of resuming the fiber in res.
 # Because the fiber f traps only errors, we know

--- a/content/docs/fibers/index.mdz
+++ b/content/docs/fibers/index.mdz
@@ -4,28 +4,28 @@
  :order 13}
 ---
 
-Janet has support for single-core asynchronous programming via coroutines, or fibers.
+Janet has support for single-core asynchronous programming via coroutines or fibers.
 Fibers allow a process to stop and resume execution later, essentially enabling
-multiple returns from a function. This allows many patterns such a schedules, generators,
+multiple returns from a function. This allows many patterns such as schedules, generators,
 iterators, live debugging, and robust error handling. Janet's error handling is actually built on
-top of fibers (when an error is thrown, the parent fiber will handle the error).
+top of fibers (when an error is thrown, control is returned to the parent fiber).
 
 A temporary return from a fiber is called a yield, and can be invoked with the @code[yield] function.
-To resume a fiber that has been yielded, use the @code[resume] function. When resume is called on a fiber,
-it will only return when that fiber either returns, yields, throws an error, or otherwise emits
-a signal.
+To resume a fiber that has been yielded, use the @code[resume] function. When
+@code`resume` is called on a fiber, it will only return when that fiber either returns, yields, throws
+an error, or otherwise emits a signal.
 
 Different from traditional coroutines, Janet's fibers implement a signaling mechanism, which
 is used to differentiate different kinds of returns. When a fiber yields or throws an error,
 control is returned to the calling fiber. The parent fiber must then check what kind of state the
-fiber is in to differentiate errors from return values from user defined signals.
+fiber is in to differentiate errors from return values from user-defined signals.
 
 To create a fiber, user the @code[fiber/new] function. The fiber constructor take one or two arguments.
 The first, necessary argument is the function that the fiber will execute. This function must accept
 an arity of zero. The next optional argument is a collection of flags checking what kinds of
 signals to trap and return via @code[resume]. This is useful so
 the programmer does not need to handle all different kinds of signals from a fiber. Any un-trapped signals
-are simply propagated to the next fiber.
+are simply propagated to the previous calling fiber.
 
 @codeblock[janet](```
 (def f (fiber/new (fn []
@@ -48,9 +48,10 @@ are simply propagated to the next fiber.
 (print (resume f)) # -> throws an error because the fiber is dead
 ```)
 
-## Using Fibers to Capture Errors
+## Using fibers to capture errors
 
-Besides being used as coroutines, fibers can be used to implement error handling (exceptions).
+Besides being used as coroutines, fibers can be used to implement error handling
+(ie: exceptions).
 
 @codeblock[janet](```
 (defn my-function-that-errors []
@@ -68,7 +69,7 @@ Besides being used as coroutines, fibers can be used to implement error handling
 
 Since the above code is rather verbose, Janet provides a
 @code[try] macro which is similar to try/catch in other languages.
-It wraps a body of code in a new fiber, @code[resume]s the fiber, and
+It wraps the body in a new fiber, @code[resume]s the fiber, and
 then checks the result. If the fiber has errored, an error clause
 is evaluated.
 

--- a/content/docs/fibers/index.mdz
+++ b/content/docs/fibers/index.mdz
@@ -4,28 +4,32 @@
  :order 13}
 ---
 
-Janet has support for single-core asynchronous programming via coroutines or fibers.
-Fibers allow a process to stop and resume execution later, essentially enabling
-multiple returns from a function. This allows many patterns such as schedules, generators,
-iterators, live debugging, and robust error handling. Janet's error handling is actually built on
-top of fibers (when an error is thrown, control is returned to the parent fiber).
+Janet has support for single-core asynchronous programming via coroutines or
+fibers.  Fibers allow a process to stop and resume execution later, essentially
+enabling multiple returns from a function. This allows many patterns such as
+schedules, generators, iterators, live debugging, and robust error handling.
+Janet's error handling is actually built on top of fibers (when an error is
+thrown, control is returned to the parent fiber).
 
-A temporary return from a fiber is called a yield, and can be invoked with the @code[yield] function.
-To resume a fiber that has been yielded, use the @code[resume] function. When
-@code`resume` is called on a fiber, it will only return when that fiber either returns, yields, throws
-an error, or otherwise emits a signal.
+A temporary return from a fiber is called a yield, and can be invoked with the
+@code[yield] function.  To resume a fiber that has been yielded, use the
+@code[resume] function. When @code`resume` is called on a fiber, it will only
+return when that fiber either returns, yields, throws an error, or otherwise
+emits a signal.
 
-Different from traditional coroutines, Janet's fibers implement a signaling mechanism, which
-is used to differentiate different kinds of returns. When a fiber yields or throws an error,
-control is returned to the calling fiber. The parent fiber must then check what kind of state the
-fiber is in to differentiate errors from return values from user-defined signals.
+Different from traditional coroutines, Janet's fibers implement a signaling
+mechanism, which is used to differentiate different kinds of returns. When a
+fiber yields or throws an error, control is returned to the calling fiber. The
+parent fiber must then check what kind of state the fiber is in to differentiate
+errors from return values from user-defined signals.
 
-To create a fiber, user the @code[fiber/new] function. The fiber constructor take one or two arguments.
-The first, necessary argument is the function that the fiber will execute. This function must accept
-an arity of zero. The next optional argument is a collection of flags checking what kinds of
-signals to trap and return via @code[resume]. This is useful so
-the programmer does not need to handle all different kinds of signals from a fiber. Any un-trapped signals
-are simply propagated to the previous calling fiber.
+To create a fiber, user the @code[fiber/new] function. The fiber constructor
+take one or two arguments.  The first, necessary argument is the function that
+the fiber will execute. This function must accept an arity of zero. The next
+optional argument is a collection of flags checking what kinds of signals to
+trap and return via @code[resume]. This is useful so the programmer does not
+need to handle all different kinds of signals from a fiber. Any un-trapped
+signals are simply propagated to the previous calling fiber.
 
 @codeblock[janet](```
 (def f (fiber/new (fn []
@@ -67,11 +71,10 @@ Besides being used as coroutines, fibers can be used to implement error handling
  (print "result contains the good result"))
 ```)
 
-Since the above code is rather verbose, Janet provides a
-@code[try] macro which is similar to try/catch in other languages.
-It wraps the body in a new fiber, @code[resume]s the fiber, and
-then checks the result. If the fiber has errored, an error clause
-is evaluated.
+Since the above code is rather verbose, Janet provides a @code[try] macro which
+is similar to try/catch in other languages.  It wraps the body in a new fiber,
+@code[resume]s the fiber, and then checks the result. If the fiber has errored,
+an error clause is evaluated.
 
 @codeblock[janet](```
 (try

--- a/content/docs/flow.mdz
+++ b/content/docs/flow.mdz
@@ -3,11 +3,13 @@
  :order 5}
 ---
 
-Janet has only two built in primitives to change flow while inside a function. The first is the
-@code[if] special form, which behaves as expected in most functional languages. It takes two or three parameters:
-a condition, an expression to evaluate to if the condition is true (not nil or false),
-and an optional condition to evaluate to when the condition is nil or false. If the optional parameter
-is omitted, the if form evaluates to nil.
+Janet has only two built in primitives to change flow while inside a function.
+The first is the @code[if] special form, which behaves as expected in most
+functional languages. It takes two or three parameters: a condition, an
+expression to evaluate to if the condition is Boolean true (ie: not @code`nil`
+or @code`false`), and an optional condition to evaluate to when the condition is
+@code`nil` or @code`false`. If the optional parameter is omitted, the @code`if`
+form evaluates to @code`nil`.
 
 @codeblock[janet](```
 (if (> 4 3)
@@ -21,12 +23,14 @@ is omitted, the if form evaluates to nil.
   (print "Oy!")) # Will not print
 ```)
 
-The second primitive control flow construct is the while loop. The while behaves much the same
-as in many other programming languages, including C, Java, and Python. The while loop takes
-two or more parameters: the first is a condition (like in the `if` statement), that is checked before
-every iteration of the loop. If it is nil or false, the while loop ends and evaluates to nil. Otherwise,
-the rest of the parameters will be evaluated sequentially and then the program will return to the beginning
-of the loop.
+The second primitive control flow construct is the @code`while` loop. The
+@code`while` form behaves much the same as in many other programming languages,
+including C, Java, and Python. The @code`while` loop takes two or more
+parameters: the first is a condition (like in the @code`if` statement), that is
+checked before every iteration of the loop. If it is @code`nil` or @code`false`,
+the @code`while` loop ends and evaluates to @code`nil`. Otherwise, the rest of
+the parameters will be evaluated sequentially and then the program will return
+to the beginning of the loop.
 
 @codeblock[janet](```
 # Loop from 100 down to 1 and print each time
@@ -41,10 +45,14 @@ of the loop.
   (print "..."))
 ```)
 
-Besides these special forms, Janet has many macros for both conditional testing and looping
-that are much better for the majority of cases. For conditional testing, the @code[cond], @code[case], and
-@code[when] macros can be used to great effect. @code[cond] can be used for making an if-else chain, where using
-just raw if forms would result in many parentheses. @code[case] is similar to switch in C without fall-through, or case in some Lisps, though simpler.  @code[when] is like if, but returns nil if the condition evaluates to nil or false, similar to the macro of the same name in Common Lisp and Clojure. For looping, @code[loop], @code[seq], and @code[generate]
-implement janet's form of list comprehension, as in Python or Clojure.
-
-
+Besides these special forms, Janet has many macros for both conditional testing
+and looping that are much better for the majority of cases. For conditional
+testing, the @code[cond], @code[case], and @code[when] macros can be used to
+great effect. @code[cond] can be used for making an if-else chain, where using
+just raw @code`if` forms would result in many parentheses. @code[case] is
+similar to @code`switch` in C without fall-through, or @code`case` in some
+Lisps, though simpler.  @code[when] is like @code`if`, but returns @code`nil` if
+the condition evaluates to @code`nil` or @code`false`, similar to the macro of
+the same name in Common Lisp and Clojure. For looping, @code[loop], @code[seq],
+and @code[generate] implement Janet's form of list comprehension, as in Python
+or Clojure.

--- a/content/docs/functions.mdz
+++ b/content/docs/functions.mdz
@@ -3,10 +3,10 @@
  :order 6}
 ---
 
-Janet is a functional language - that means that one of the basic building blocks of your
-program will be defining functions (the other is using data structures). Because Janet
-is a Lisp-like language, functions are values just like numbers or strings - they can be passed around and
-created as needed.
+Janet is a functional language - that means that one of the basic building
+blocks of your program will be defining functions (the other is using data
+structures). Because Janet is a Lisp-like language, functions are values just
+like numbers or strings - they can be passed around and created as needed.
 
 Functions can be defined with the @code[defn] macro, like so:
 
@@ -18,24 +18,26 @@ Functions can be defined with the @code[defn] macro, like so:
  (* base height 0.5))
 ```)
 
-A function defined with @code[defn] consists of a name, a number of optional flags for @code`def`, and
-finally a function body. The example above is named triangle-area and takes two parameters named
-base and height. The body of the function will print a message and then evaluate to the area of the triangle.
+A function defined with @code[defn] consists of a name, a number of optional
+flags for @code`def`, and finally a function body. The example above is named
+triangle-area and takes two parameters named base and height. The body of the
+function will print a message and then evaluate to the area of the triangle.
 
-Once a function like the above one is defined, the programmer can use the @code[triangle-area]
-function just like any other, say @code[print] or @code[+].
+Once a function like the above one is defined, the programmer can use the
+@code[triangle-area] function just like any other, say @code[print] or @code[+].
 
 @codeblock[janet](```
 # Prints "calculating area of a triangle..." and then "25"
 (print (triangle-area 5 10))
 ```)
 
-Note that when nesting function calls in other function calls like above (a call to @code`triangle-area` is
-nested inside a call to @code`print`), the inner function calls are evaluated first. Additionally, arguments to
-a function call are evaluated in order, from first argument to last argument).
+Note that when nesting function calls in other function calls like above (a call
+to @code`triangle-area` is nested inside a call to @code`print`), the inner
+function calls are evaluated first. Additionally, arguments to a function call
+are evaluated in order, from first argument to last argument).
 
-Because functions are first-class values like numbers or strings, they can be passed
-as arguments to other functions as well.
+Because functions are first-class values like numbers or strings, they can be
+passed as arguments to other functions as well.
 
 @codeblock[janet](```
 (print triangle-area)
@@ -43,8 +45,8 @@ as arguments to other functions as well.
 
 This prints the location in memory of the function @code`triangle-area`.
 
-Functions don't need to have names. The @code[fn] keyword can be used to introduce function
-literals without binding them to a symbol.
+Functions don't need to have names. The @code[fn] keyword can be used to
+introduce function literals without binding them to a symbol.
 
 @codeblock[janet](```
 # Evaluates to 40
@@ -58,13 +60,14 @@ literals without binding them to a symbol.
 ((fn [x &] x) 1 2)
 ```)
 
-The first expression creates an anonymous function that adds twice
-the first argument to the second, and then calls that function with arguments 10 and 20.
+The first expression creates an anonymous function that adds twice the first
+argument to the second, and then calls that function with arguments 10 and 20.
 This will return (10 + 10 + 20) = 40.
 
-There is a common macro @code[defn] that can be used for creating functions and immediately binding
-them to a name. @code[defn] works as expected at both the top level and inside another form. There is also
-the corresponding macro @code`defmacro` that does the same kind of wrapping for macros.
+There is a common macro @code[defn] that can be used for creating functions and
+immediately binding them to a name. @code[defn] works as expected at both the
+top level and inside another form. There is also the corresponding macro
+@code`defmacro` that does the same kind of wrapping for macros.
 
 @codeblock[janet]```
 (defn myfun [x y]
@@ -77,18 +80,17 @@ the corresponding macro @code`defmacro` that does the same kind of wrapping for 
 (myfun 3 4) # -> 10
 ```
 
-Janet has many macros provided for you (and you can write your own).
-Macros are just functions that take your source code
-and transform it into some other source code, usually automating some repetitive pattern for you.
+Janet has many macros provided for you (and you can write your own).  Macros are
+just functions that take your source code and transform it into some other
+source code, usually automating some repetitive pattern for you.
 
 ## Optional arguments
 
-Most Janet functions will raise an error at runtime
-if not passed exactly the right number of arguments.
-Sometimes, you want to define a function with optional arguments, where the arguments
-take a default value if not supplied by the caller. Janet has support for this via
-the @code`&opt` symbol in parameter lists, where all parameters after @code`&opt` are
-@code`nil` if not supplied.
+Most Janet functions will raise an error at runtime if not passed exactly the
+right number of arguments.  Sometimes, you want to define a function with
+optional arguments, where the arguments take a default value if not supplied by
+the caller. Janet has support for this via the @code`&opt` symbol in parameter
+lists, where all parameters after @code`&opt` are @code`nil` if not supplied.
 
 @codeblock[janet]```
 (defn my-opt-function
@@ -100,15 +102,17 @@ the @code`&opt` symbol in parameter lists, where all parameters after @code`&opt
  (+ a b c d e f))
 ```
 
-The @code`(default)` macro is a useful macro for setting default values for parameters. If a parameter
-is @code`nil`, @code`(default)` will redefine it to a default value.
+The @code`(default)` macro is a useful macro for setting default values for
+parameters. If a parameter is @code`nil`, @code`(default)` will redefine it to a
+default value.
 
 ## Variadic functions
 
-Janet also provides first-class support for variadic functions. Variadic functions can take any number
-of parameters, and gather them up into a tuple. To define a variadic function, use the @code`&` symbol
-as the second to last item of the parameter list. Parameters defined before the last variadic argument
-are not optional, unless specified as so with the @code`&opt` symbol.
+Janet also provides first-class support for variadic functions. Variadic
+functions can take any number of parameters, and gather them up into a tuple. To
+define a variadic function, use the @code`&` symbol as the second to last item
+of the parameter list. Parameters defined before the last variadic argument are
+not optional, unless specified as so with the @code`&opt` symbol.
 
 @codeblock[janet]```
 (defn my-adder
@@ -124,10 +128,11 @@ are not optional, unless specified as so with the @code`&opt` symbol.
 
 ## Ignoring extra arguments
 
-Sometimes you may want to have a function that can take a number of extra arguments but not
-use them. This happens because a function may be part of an interface, but the function itself
-doesn't need those arguments. You can write a function that will simply drop extra parameters
-by adding @code`&` as the last parameter in the function.
+Sometimes you may want to have a function that can take a number of extra
+arguments but not use them. This happens because a function may be part of an
+interface, but the function itself doesn't need those arguments. You can write a
+function that will simply drop extra parameters by adding @code`&` as the last
+parameter in the function.
 
 @codeblock[janet]```
 (defn ignore-extra
@@ -139,11 +144,11 @@ by adding @code`&` as the last parameter in the function.
 
 ## Keyword-style arguments
 
-Sometimes, you want a function to have many arguments, and calling
-such a function can get confusing without naming the arguments in the call.
-One solution to this problem is passing a table or struct with all of the
-arguments you want to use. This is in general a good approach, as now your
-original arguments can be identified by the keys in the struct.
+Sometimes, you want a function to have many arguments, and calling such a
+function can get confusing without naming the arguments in the call.  One
+solution to this problem is passing a table or struct with all of the arguments
+you want to use. This is in general a good approach, as now your original
+arguments can be identified by the keys in the struct.
 
 @codeblock[janet]```
 (defn make-recipe
@@ -195,9 +200,10 @@ We can solve this first problem by using destructuring in the argument.
   :vanilla-extract 0.5})
 ```
 
-The docstring of the improved function will contain a list of arguments that our function takes.
-To fix the second issue, we can use the &keys symbol in a function parameter list to automatically
-create our big argument struct for use on invocation.
+The docstring of the improved function will contain a list of arguments that our
+function takes.  To fix the second issue, we can use the &keys symbol in a
+function parameter list to automatically create our big argument struct for use
+on invocation.
 
 @codeblock[janet]```
 (defn make-recipe-3
@@ -222,16 +228,19 @@ create our big argument struct for use on invocation.
   :vanilla-extract 0.5)
 ```
 
-Usage of this last variant looks cleaner than the previous two recipe-making functions, but
-there is a caveat. Having all of the arguments packaged as a struct is often useful, as the
-struct can be passed around and threaded through an application efficiently. Functions that
-require many arguments often pass those arguments to subroutines, so in practice this issue is quite
-common. The @code`&keys` syntax
-is therefore most useful where terseness and visual clarity is more important.
+Usage of this last variant looks cleaner than the previous two recipe-making
+functions, but there is a caveat. Having all of the arguments packaged as a
+struct is often useful, as the struct can be passed around and threaded through
+an application efficiently. Functions that require many arguments often pass
+those arguments to subroutines, so in practice this issue is quite common. The
+@code`&keys` syntax is therefore most useful where terseness and visual clarity
+is more important.
 
-It is not difficult to convert between the two calling styles, if need be. To pass a struct to a function that expects @code`&keys`-style arguments, the @code`kvs` function works well. To convert
-arguments in the other direction, from @code`&keys`-style to a single struct argument, is trivial -
-just wrap your arguments in curly brackets!
+It is not difficult to convert between the two calling styles, if need be. To
+pass a struct to a function that expects @code`&keys`-style arguments, the
+@code`kvs` function works well. To convert arguments in the other direction,
+from @code`&keys`-style to a single struct argument, is trivial - just wrap your
+arguments in curly brackets!
 
 @codeblock[janet]```
 (def args

--- a/content/docs/functions.mdz
+++ b/content/docs/functions.mdz
@@ -4,8 +4,8 @@
 ---
 
 Janet is a functional language - that means that one of the basic building blocks of your
-program will be defining functions (the other is using data structures). Because janet
-is Lisp-like language, functions are values just like numbers or strings - they can be passed around and
+program will be defining functions (the other is using data structures). Because Janet
+is a Lisp-like language, functions are values just like numbers or strings - they can be passed around and
 created as needed.
 
 Functions can be defined with the @code[defn] macro, like so:
@@ -18,7 +18,7 @@ Functions can be defined with the @code[defn] macro, like so:
  (* base height 0.5))
 ```)
 
-A function defined with @code[defn] consists of a name, a number of optional flags for def, and
+A function defined with @code[defn] consists of a name, a number of optional flags for @code`def`, and
 finally a function body. The example above is named triangle-area and takes two parameters named
 base and height. The body of the function will print a message and then evaluate to the area of the triangle.
 
@@ -30,8 +30,8 @@ function just like any other, say @code[print] or @code[+].
 (print (triangle-area 5 10))
 ```)
 
-Note that when nesting function calls in other function calls like above (a call to triangle-area is
-nested inside a call to print), the inner function calls are evaluated first. Also, arguments to
+Note that when nesting function calls in other function calls like above (a call to @code`triangle-area` is
+nested inside a call to @code`print`), the inner function calls are evaluated first. Additionally, arguments to
 a function call are evaluated in order, from first argument to last argument).
 
 Because functions are first-class values like numbers or strings, they can be passed
@@ -41,7 +41,7 @@ as arguments to other functions as well.
 (print triangle-area)
 ```)
 
-This prints the location in memory of the function triangle area.
+This prints the location in memory of the function @code`triangle-area`.
 
 Functions don't need to have names. The @code[fn] keyword can be used to introduce function
 literals without binding them to a symbol.
@@ -81,7 +81,7 @@ Janet has many macros provided for you (and you can write your own).
 Macros are just functions that take your source code
 and transform it into some other source code, usually automating some repetitive pattern for you.
 
-## Optional Arguments
+## Optional arguments
 
 Most Janet functions will raise an error at runtime
 if not passed exactly the right number of arguments.
@@ -101,13 +101,13 @@ the @code`&opt` symbol in parameter lists, where all parameters after @code`&opt
 ```
 
 The @code`(default)` macro is a useful macro for setting default values for parameters. If a parameter
-is nil, @code`(default)` will redefine it to a default value.
+is @code`nil`, @code`(default)` will redefine it to a default value.
 
-## Variadic Functions
+## Variadic functions
 
 Janet also provides first-class support for variadic functions. Variadic functions can take any number
 of parameters, and gather them up into a tuple. To define a variadic function, use the @code`&` symbol
-as the second to last item if the parameter list. Parameters defined before the last variadic argument
+as the second to last item of the parameter list. Parameters defined before the last variadic argument
 are not optional, unless specified as so with the @code`&opt` symbol.
 
 @codeblock[janet]```
@@ -122,7 +122,7 @@ are not optional, unless specified as so with the @code`&opt` symbol.
 (my-adder 1 2 3) # -> 6
 ```
 
-## Ignoring Extra Arguments
+## Ignoring extra arguments
 
 Sometimes you may want to have a function that can take a number of extra arguments but not
 use them. This happens because a function may be part of an interface, but the function itself
@@ -137,7 +137,7 @@ by adding @code`&` as the last parameter in the function.
 (ignore-extra 1 2 3 4 5) # -> 2
 ```
 
-## Keyword Style Arguments
+## Keyword-style arguments
 
 Sometimes, you want a function to have many arguments, and calling
 such a function can get confusing without naming the arguments in the call.
@@ -164,8 +164,11 @@ original arguments can be identified by the keys in the struct.
 ```
 
 This is often good enough, but there are a couple downsides. The first is that
-our semantic arguments are not documented, the docstring will just have a single argument "args" which is not helpful. The docstring should have some indication of they keys that we expect in the struct.
-We also need to write out an extra pair of brackets for the struct - this isn't a huge deal, but it would be nice if we didn't need to write this out explicitly.
+our semantic arguments are not documented, the docstring will just have a single
+argument "args" which is not helpful. The docstring should have some indication
+of they keys that we expect in the struct.  We also need to write out an extra
+pair of brackets for the struct - this isn't a huge deal, but it would be nice
+if we didn't need to write this explicitly.
 
 We can solve this first problem by using destructuring in the argument.
 
@@ -219,12 +222,12 @@ create our big argument struct for use on invocation.
   :vanilla-extract 0.5)
 ```
 
-Usage of this last variant looks cleaner than the previous two recipe making functions, but
-there is a caveat. Having all of the arguments packaged as a struct is often useful, as the 
+Usage of this last variant looks cleaner than the previous two recipe-making functions, but
+there is a caveat. Having all of the arguments packaged as a struct is often useful, as the
 struct can be passed around and threaded through an application efficiently. Functions that
 require many arguments often pass those arguments to subroutines, so in practice this issue is quite
 common. The @code`&keys` syntax
-is therefor most useful where terseness and visual clarity is more important.
+is therefore most useful where terseness and visual clarity is more important.
 
 It is not difficult to convert between the two calling styles, if need be. To pass a struct to a function that expects @code`&keys`-style arguments, the @code`kvs` function works well. To convert
 arguments in the other direction, from @code`&keys`-style to a single struct argument, is trivial -

--- a/content/docs/index.mdz
+++ b/content/docs/index.mdz
@@ -7,22 +7,24 @@
 
 ## Installation
 
-Install a stable version of janet from the @link[https://github.com/janet-lang/janet/releases][releases page].
-Janet is prebuilt for a few systems, but if you want to develop janet, run janet on a non-x86 system, or
-get the latest, you must build janet from source.
+Install a stable version of Janet from the @link[https://github.com/janet-lang/janet/releases][releases page].
+Janet is prebuilt for a few systems, but if you want to develop Janet, run Janet on a non-x86 system, or
+get the latest, you must build Janet from source.
 
 ### Windows
 
-The recommended way to install on windows is just to run the installer from the releases page.
-A scoop package was maintained previously, but ongoing support is being dropped.
+The recommended way to install on Windows is just to run the installer from the releases page.
+A Scoop package was maintained previously, but ongoing support is being dropped.
 
 If you want to use @code`jpm` to install native extensions, you will also need to install Visual Studio, ideally
-a recent release (2019 and 2017 should work well). Then, running @code`jpm` from the x64 Native Tools
-command prompt should work for a 64 bit build, and the Developer Command Prompt should work for 32 bit builds.
-Using these specific command prompts for jpm simply lets jpm use the Microsoft Compiler to compile native modules
+a recent release (2019 or 2017 should work well). Then, running @code`jpm` from the x64 Native Tools
+Command Prompt should work for a 64-bit build, and from the Developer Command Prompt should work for 32-bit builds.
+Using these specific command prompts for @code`jpm` simply lets @code`jpm` use the Microsoft compiler to compile native modules
 on install.
 
-### AUR
+### Linux
+
+#### Arch Linux
 
 You can install either the latest git verion or the latest stable version for Arch Linux
 from the Arch user repositories with @link[https://aur.archlinux.org/packages/janet-lang-git/][janet-lang-git] or @link[https://aur.archlinux.org/packages/janet-lang][janet-lang].
@@ -37,18 +39,19 @@ manager as @code[janet]. The latest version from git can be installed by adding 
 brew install janet
 ```)
 
-## Compiling and Running from Source
+## Compiling and running from source
 
 If you would like the latest version of Janet, are trying to run Janet on
 a platform that is not macOS or Windows, or would like to help develop
-Janet, you can build janet from source.
-Janet only uses Make and batch files to compile on Posix and windows
-respectively. To configure janet, edit the header file src/conf/janetconf.h
+Janet, you can build Janet from source.
+Janet only uses Make and batch files to compile on POSIX and Windows
+respectively. To configure Janet, edit the header file @code`src/conf/janetconf.h`
 before compilation.
 
 ### macOS and Unix-like
 
-On most platforms, use Make to build janet. The resulting binary will be in @code[build/janet].
+On most platforms, use Make to build Janet. The resulting files (including the
+@code`janet` binary) will be in the @code[build/] directory.
 
 @codeblock(```
 cd somewhere/my/projects/janet
@@ -56,12 +59,12 @@ make
 make test
 ```)
 
-After building, run @code[make install] to install the janet binary and libs.
-Will install in @code[/usr/local] by default, see the Makefile to customize.
+After building, run @code[make install] to install the @code`janet` binary and libraries.
+This will install in @code[/usr/local] by default, see the Makefile to customize.
 
 ### FreeBSD
 
-FreeBSD build instructions are the same as the unix-like build instuctions,
+FreeBSD build instructions are the same as the Unix-like build instuctions,
 but you need @code[gmake] and @code[gcc] to compile.
 
 @codeblock(```
@@ -74,38 +77,38 @@ gmake test CC=gcc
 
 @ol{@li{Install @link[https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=15#][Visual Studio] or
     @link[https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15#][Visual Studio Build Tools]}
-    @li{Run a Visual Studio Command Prompt (cl.exe and link.exe need to be on the PATH)}
-    @li{@code[cd] to the directory with janet}
-    @li{Run @code[build_win] to compile janet.}
+    @li{Run a Visual Studio Command Prompt (@code`cl.exe` and @code`link.exe` need to be on the PATH)}
+    @li{@code[cd] to the directory with Janet}
+    @li{Run @code[build_win] to compile Janet.}
     @li{Run @code[build_win test] to make sure everything is working.}}
 
 To install from source, first follow the steps above, then you will need to
 
 @ol{@li{Install, or otherwise add to your PATH, the @link[https://github.com/wixtoolset/wix3/releases]{WiX 3.11 Toolset}}
-    @li{Run a Visual Studio Command Prompt (cl.exe and link.exe need to be on the PATH)}
-    @li{@code[cd] to the directory with janet}
+    @li{Run a Visual Studio Command Prompt (@code`cl.exe` and @code`link.exe` need to be on the PATH)}
+    @li{@code[cd] to the directory with Janet}
     @li{Run @code[build_win dist]}
     @li{Then, lastly, execute the resulting @code[.msi] executable}}
 
 ### Emscripten
 
-To build janet for the web via @link[https://kripken.github.io/emscripten-site/][Emscripten], make sure you
-have @code[emcc] installed and on your path. On a linux or macOS system, use @code[make emscripten] to build
-@code[janet.js] and @code[janet.wasm] - both are needed to run janet in a browser or in node.
-The JavaScript build is what runs the repl on the main website,
+To build Janet for the web via @link[https://kripken.github.io/emscripten-site/][Emscripten], make sure you
+have @code[emcc] installed and on your path. On a Linux or macOS system, use @code[make emscripten] to build
+@code[janet.js] and @code[janet.wasm] - both are needed to run Janet in a browser or in Node.js.
+The JavaScript build is what runs the REPL on the main website,
 but really serves mainly as a proof of concept. Janet will run slower in a browser.
-Building with emscripten on windows is currently unsupported.
+Building with Emscripten on Windows is currently unsupported.
 
 ### Meson
 
-Janet also has a build file for @link[https://mesonbuild.com/][Meson], a cross platform build
+Janet also has a build file for @link[https://mesonbuild.com/][Meson], a cross-platform build
 system. This is not currently the main supported build system, but should work on any
-system that supports meson. Meson also provides much better IDE integration than Make or batch files.
+system that supports Meson. Meson also provides much better IDE integration than Make or batch files.
 
 ### Small builds
 
 If you want to cut down on the size of the final Janet binary or library, you need to omit features
-and build with @code`-Os`. With meson, this can look something like below:
+and build with @code`-Os`. With Meson, this can look something like below:
 
 @codeblock```
 git clone https://github.com/janet-lang/janet.git
@@ -122,7 +125,7 @@ ninja
 You can also do this with the Makefile by editing @code`CFLAGS`, and uncommenting some lines
 in @code`src/conf/janetconf.h`.
 
-## First Program
+## First program
 
 Following tradition, a simple Janet program will print "Hello, world!".
 
@@ -130,15 +133,15 @@ Following tradition, a simple Janet program will print "Hello, world!".
 
 Put the following code in a file named @code[hello.janet], and run @code[janet hello.janet].
 The words "Hello, world!" should be printed to the console, and then the program
-should immediately exit. You now have a working janet program!
+should immediately exit. You now have a working Janet program!
 
 Alternatively, run the program @code[janet] without any arguments to enter a REPL,
-or read eval print loop. This is a mode where Janet works like a calculator,
+or read-eval-print-loop. This is a mode where Janet works like a calculator,
 reading some input from the user, evaluating it, and printing out the result, all
 in an infinite loop. This is a useful mode for exploring or prototyping in Janet.
 
 This hello world program is about the simplest program one can write, and consists of only
-a few pieces of syntax. This first element is the @code[print] symbol. This is a function
+a few pieces of syntax. The first element is the @code[print] symbol. This is a function
 that simply prints its arguments to the console. The second argument is the
 string literal "Hello, world!", which is the one and only argument to the
 print function. Lastly, the @code[print] symbol and the string literal are wrapped
@@ -146,12 +149,12 @@ in parentheses, forming a tuple. In Janet, parentheses and brackets are intercha
 brackets are used mostly when the resulting tuple is not a function call. The tuple
 above indicates that the function @code[print] is to be called with one argument, @code["Hello, world"].
 
-All operations in Janet are in prefix notation; the name of the
+All operations in Janet are in prefix notation: the name of the
 operator is the first value in the tuple, and the arguments passed to it are
 in the rest of the tuple. While this may be familiar in function calls, in Janet this
 idea extends to arithmetic and all control forms.
 
-## The Core Library
+## The core library
 
 Janet has a built in core library of over 300 functions and macros at the time of writing.
 For efficient programming in Janet, it is good to be able to make use of many of these
@@ -166,5 +169,5 @@ To see a list of all global functions in the REPL, type the command
 
 @codeblock[janet](```(all-bindings)```)
 
-Which will print out every global binding in the janet REPL. You can also
-browse the @link[/doc.html][Core Library API on the website].
+Which will print out every global binding in the Janet REPL. You can also
+browse the @link[/doc.html][core library API] on the website.

--- a/content/docs/index.mdz
+++ b/content/docs/index.mdz
@@ -7,33 +7,38 @@
 
 ## Installation
 
-Install a stable version of Janet from the @link[https://github.com/janet-lang/janet/releases][releases page].
-Janet is prebuilt for a few systems, but if you want to develop Janet, run Janet on a non-x86 system, or
-get the latest, you must build Janet from source.
+Install a stable version of Janet from the
+@link[https://github.com/janet-lang/janet/releases][releases page].  Janet is
+prebuilt for a few systems, but if you want to develop Janet, run Janet on a
+non-x86 system, or get the latest, you must build Janet from source.
 
 ### Windows
 
-The recommended way to install on Windows is just to run the installer from the releases page.
-A Scoop package was maintained previously, but ongoing support is being dropped.
+The recommended way to install on Windows is just to run the installer from the
+releases page.  A Scoop package was maintained previously, but ongoing support
+is being dropped.
 
-If you want to use @code`jpm` to install native extensions, you will also need to install Visual Studio, ideally
-a recent release (2019 or 2017 should work well). Then, running @code`jpm` from the x64 Native Tools
-Command Prompt should work for a 64-bit build, and from the Developer Command Prompt should work for 32-bit builds.
-Using these specific command prompts for @code`jpm` simply lets @code`jpm` use the Microsoft compiler to compile native modules
-on install.
+If you want to use @code`jpm` to install native extensions, you will also need
+to install Visual Studio, ideally a recent release (2019 or 2017 should work
+well). Then, running @code`jpm` from the x64 Native Tools Command Prompt should
+work for a 64-bit build, and from the Developer Command Prompt should work for
+32-bit builds.  Using these specific command prompts for @code`jpm` simply lets
+@code`jpm` use the Microsoft compiler to compile native modules on install.
 
 ### Linux
 
 #### Arch Linux
 
-You can install either the latest git verion or the latest stable version for Arch Linux
-from the Arch user repositories with @link[https://aur.archlinux.org/packages/janet-lang-git/][janet-lang-git] or @link[https://aur.archlinux.org/packages/janet-lang][janet-lang].
+You can install either the latest git verion or the latest stable version for
+Arch Linux from the Arch user repositories with
+@link[https://aur.archlinux.org/packages/janet-lang-git/][janet-lang-git] or
+@link[https://aur.archlinux.org/packages/janet-lang][janet-lang].
 
 ### macOS
 
-Janet is available for installation through the @link[https://brew.sh/][homebrew] package
-manager as @code[janet]. The latest version from git can be installed by adding the
-@code[--HEAD] flag.
+Janet is available for installation through the
+@link[https://brew.sh/][homebrew] package manager as @code[janet]. The latest
+version from git can be installed by adding the @code[--HEAD] flag.
 
 @codeblock(```
 brew install janet
@@ -41,12 +46,11 @@ brew install janet
 
 ## Compiling and running from source
 
-If you would like the latest version of Janet, are trying to run Janet on
-a platform that is not macOS or Windows, or would like to help develop
-Janet, you can build Janet from source.
-Janet only uses Make and batch files to compile on POSIX and Windows
-respectively. To configure Janet, edit the header file @code`src/conf/janetconf.h`
-before compilation.
+If you would like the latest version of Janet, are trying to run Janet on a
+platform that is not macOS or Windows, or would like to help develop Janet, you
+can build Janet from source.  Janet only uses Make and batch files to compile on
+POSIX and Windows respectively. To configure Janet, edit the header file
+@code`src/conf/janetconf.h` before compilation.
 
 ### macOS and Unix-like
 
@@ -59,13 +63,14 @@ make
 make test
 ```)
 
-After building, run @code[make install] to install the @code`janet` binary and libraries.
-This will install in @code[/usr/local] by default, see the Makefile to customize.
+After building, run @code[make install] to install the @code`janet` binary and
+libraries.  This will install in @code[/usr/local] by default, see the Makefile
+to customize.
 
 ### FreeBSD
 
-FreeBSD build instructions are the same as the Unix-like build instuctions,
-but you need @code[gmake] and @code[gcc] to compile.
+FreeBSD build instructions are the same as the Unix-like build instuctions, but
+you need @code[gmake] and @code[gcc] to compile.
 
 @codeblock(```
 cd somewhere/my/projects/janet
@@ -75,40 +80,47 @@ gmake test CC=gcc
 
 ### Windows
 
-@ol{@li{Install @link[https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=15#][Visual Studio] or
-    @link[https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15#][Visual Studio Build Tools]}
-    @li{Run a Visual Studio Command Prompt (@code`cl.exe` and @code`link.exe` need to be on the PATH)}
+@ol{@li{Install @link[https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=15#][Visual Studio]
+        or @link[https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15#][Visual Studio Build Tools]}
+    @li{Run a Visual Studio Command Prompt (@code`cl.exe` and @code`link.exe`
+        need to be on the PATH)}
     @li{@code[cd] to the directory with Janet}
     @li{Run @code[build_win] to compile Janet.}
     @li{Run @code[build_win test] to make sure everything is working.}}
 
 To install from source, first follow the steps above, then you will need to
 
-@ol{@li{Install, or otherwise add to your PATH, the @link[https://github.com/wixtoolset/wix3/releases]{WiX 3.11 Toolset}}
-    @li{Run a Visual Studio Command Prompt (@code`cl.exe` and @code`link.exe` need to be on the PATH)}
+@ol{@li{Install, or otherwise add to your PATH, the
+        @link[https://github.com/wixtoolset/wix3/releases]{WiX 3.11 Toolset}}
+    @li{Run a Visual Studio Command Prompt (@code`cl.exe` and @code`link.exe`
+        need to be on the PATH)}
     @li{@code[cd] to the directory with Janet}
     @li{Run @code[build_win dist]}
     @li{Then, lastly, execute the resulting @code[.msi] executable}}
 
 ### Emscripten
 
-To build Janet for the web via @link[https://kripken.github.io/emscripten-site/][Emscripten], make sure you
-have @code[emcc] installed and on your path. On a Linux or macOS system, use @code[make emscripten] to build
-@code[janet.js] and @code[janet.wasm] - both are needed to run Janet in a browser or in Node.js.
-The JavaScript build is what runs the REPL on the main website,
-but really serves mainly as a proof of concept. Janet will run slower in a browser.
-Building with Emscripten on Windows is currently unsupported.
+To build Janet for the web via
+@link[https://kripken.github.io/emscripten-site/][Emscripten], make sure you
+have @code[emcc] installed and on your path. On a Linux or macOS system, use
+@code[make emscripten] to build @code[janet.js] and @code[janet.wasm] - both are
+needed to run Janet in a browser or in Node.js. The JavaScript build is what
+runs the REPL on the main website, but really serves mainly as a proof of
+concept. Janet will run slower in a browser. Building with Emscripten on Windows
+is currently unsupported.
 
 ### Meson
 
-Janet also has a build file for @link[https://mesonbuild.com/][Meson], a cross-platform build
-system. This is not currently the main supported build system, but should work on any
-system that supports Meson. Meson also provides much better IDE integration than Make or batch files.
+Janet also has a build file for @link[https://mesonbuild.com/][Meson], a
+cross-platform build system. This is not currently the main supported build
+system, but should work on any system that supports Meson. Meson also provides
+much better IDE integration than Make or batch files.
 
 ### Small builds
 
-If you want to cut down on the size of the final Janet binary or library, you need to omit features
-and build with @code`-Os`. With Meson, this can look something like below:
+If you want to cut down on the size of the final Janet binary or library, you
+need to omit features and build with @code`-Os`. With Meson, this can look
+something like below:
 
 @codeblock```
 git clone https://github.com/janet-lang/janet.git
@@ -122,8 +134,8 @@ ninja
 # ./janet should be about 40% smaller than the default build as of 2019-10-13
 ```
 
-You can also do this with the Makefile by editing @code`CFLAGS`, and uncommenting some lines
-in @code`src/conf/janetconf.h`.
+You can also do this with the Makefile by editing @code`CFLAGS`, and
+uncommenting some lines in @code`src/conf/janetconf.h`.
 
 ## First program
 
@@ -131,37 +143,39 @@ Following tradition, a simple Janet program will print "Hello, world!".
 
 @codeblock[janet](```(print "Hello, world!")```)
 
-Put the following code in a file named @code[hello.janet], and run @code[janet hello.janet].
-The words "Hello, world!" should be printed to the console, and then the program
-should immediately exit. You now have a working Janet program!
+Put the following code in a file named @code[hello.janet], and run @code[janet
+hello.janet].  The words "Hello, world!" should be printed to the console, and
+then the program should immediately exit. You now have a working Janet program!
 
-Alternatively, run the program @code[janet] without any arguments to enter a REPL,
-or read-eval-print-loop. This is a mode where Janet works like a calculator,
-reading some input from the user, evaluating it, and printing out the result, all
-in an infinite loop. This is a useful mode for exploring or prototyping in Janet.
+Alternatively, run the program @code[janet] without any arguments to enter a
+REPL, or read-eval-print-loop. This is a mode where Janet works like a
+calculator, reading some input from the user, evaluating it, and printing out
+the result, all in an infinite loop. This is a useful mode for exploring or
+prototyping in Janet.
 
-This hello world program is about the simplest program one can write, and consists of only
-a few pieces of syntax. The first element is the @code[print] symbol. This is a function
-that simply prints its arguments to the console. The second argument is the
-string literal "Hello, world!", which is the one and only argument to the
-print function. Lastly, the @code[print] symbol and the string literal are wrapped
-in parentheses, forming a tuple. In Janet, parentheses and brackets are interchangeable,
-brackets are used mostly when the resulting tuple is not a function call. The tuple
-above indicates that the function @code[print] is to be called with one argument, @code["Hello, world"].
+This hello world program is about the simplest program one can write, and
+consists of only a few pieces of syntax. The first element is the @code[print]
+symbol. This is a function that simply prints its arguments to the console. The
+second argument is the string literal "Hello, world!", which is the one and only
+argument to the print function. Lastly, the @code[print] symbol and the string
+literal are wrapped in parentheses, forming a tuple. In Janet, parentheses and
+brackets are interchangeable, brackets are used mostly when the resulting tuple
+is not a function call. The tuple above indicates that the function @code[print]
+is to be called with one argument, @code["Hello, world"].
 
-All operations in Janet are in prefix notation: the name of the
-operator is the first value in the tuple, and the arguments passed to it are
-in the rest of the tuple. While this may be familiar in function calls, in Janet this
-idea extends to arithmetic and all control forms.
+All operations in Janet are in prefix notation: the name of the operator is the
+first value in the tuple, and the arguments passed to it are in the rest of the
+tuple. While this may be familiar in function calls, in Janet this idea extends
+to arithmetic and all control forms.
 
 ## The core library
 
-Janet has a built in core library of over 300 functions and macros at the time of writing.
-For efficient programming in Janet, it is good to be able to make use of many of these
-functions.
+Janet has a built in core library of over 300 functions and macros at the time
+of writing.  For efficient programming in Janet, it is good to be able to make
+use of many of these functions.
 
-If at any time you want to see short documentation on
-a binding, use the @code[doc] macro to view the documentation for it in the REPL.
+If at any time you want to see short documentation on a binding, use the
+@code[doc] macro to view the documentation for it in the REPL.
 
 @codeblock[janet](```(doc defn) # -> Prints the documentation for "defn"```)
 
@@ -169,5 +183,5 @@ To see a list of all global functions in the REPL, type the command
 
 @codeblock[janet](```(all-bindings)```)
 
-Which will print out every global binding in the Janet REPL. You can also
-browse the @link[/doc.html][core library API] on the website.
+Which will print out every global binding in the Janet REPL. You can also browse
+the @link[/doc.html][core library API] on the website.

--- a/content/docs/jpm.mdz
+++ b/content/docs/jpm.mdz
@@ -3,20 +3,20 @@
  :order 19}
 ---
 
-Most default installs of janet come with a build tool, @code`jpm`, that makes
+Most default installs of Janet come with a build tool, @code`jpm`, that makes
 managing dependencies, building Janet code, and distributing Janet applications
 easy. While @code`jpm` is not required by Janet, it is a very handy build tool
 that removes much of the boilerplate for creating new Janet projects, and is
-updated in step with Janet. @code`jpm` also works on Windows, linux, and macOS
+updated in step with Janet. @code`jpm` also works on Windows, Linux, and macOS
 so you don't need to write multiple build scripts and worry about platform
 quirks to make your scripts, binaries, and applications cross-platform.
 
 @p{
-@code`jpm`'s main functions are installing dependencies and building native janet
-    modules, but it is meant to be used for much of the life-cycle for janet
+@code`jpm`'s main functions are installing dependencies and building native Janet
+    modules, but it is meant to be used for much of the life-cycle for Janet
     projects. Since Janet code doesn't usually need to
     be compiled, you don't always need @code`jpm`, especially for scripts, but @code`jpm`
-    comes with some functionality that is difficult to duplicate, like compiling janet source code
+    comes with some functionality that is difficult to duplicate, like compiling Janet source code
     and all imported modules into a statically linked executable for distribution.
 }
 
@@ -29,9 +29,9 @@ correspond to a single git repository, and contain a single library. However, a
 project's @code`project.janet` file can contain build recipes for as many
 libraries, native extensions, and executables as it wants. Each of these
 recipes builds an artifact. Artifacts are the output files that will either be
-distributed or installed on the end user or developer's machine.
+distributed or installed on the end-user or developer's machine.
 
-## Building Projects with @code`jpm`
+## Building projects with @code`jpm`
 
 Once you have the project on your machine, building the
 various artifacts should be pretty simple.
@@ -45,8 +45,8 @@ jpm test
 sudo jpm install
 ```
 
-\(On windows, sudo is not required. Use of sudo on posix systems depends if you installed
- janet to a directory owned by the root user.)
+\(On Windows, @code`sudo` is not required. Use of @code`sudo` on POSIX systems
+depends on whether you installed @code`janet` to a directory owned by the root user.)
 
 #### Local install
 
@@ -61,7 +61,7 @@ jpm install
 ### Dependencies
 
 @p{
-@code`jpm deps` is a command that installs Janet libraries that this software depends on recursively.
+@code`jpm deps` is a command that installs Janet libraries that the project depends on recursively.
     It will automatically fetch, build, and install all required dependencies for you.
     As of August 2019, this only works with git, which you need to have installed on your
     machine to install dependencies. If you don't have git you are free to manually
@@ -72,18 +72,18 @@ jpm install
 
 Next, we use the @code`jpm build` command to build artifacts. All built
 artifacts will be created in the @code`build` subdirectory of the current
-project. Therefore, it is probably a good idea to exclude the build directory
+project. Therefore, it is probably a good idea to exclude the @code`build` directory
 from source control. For building executables and native modules, you will need
-to have a C compiler on your PATH where you ran @code`jpm build`. For posix
+to have a C compiler on your PATH where you run @code`jpm build`. For POSIX
 systems, the compiler is @code`cc`.
 
 If you make changes to the source code after building once, @code`jpm` will
 try to only rebuild what is needed on a rebuild. If this fails for any reason, you
 can delete the entire build directory with @code`jpm clean` to reset things.
 
-### Windows
+#### Windows
 
-For windows, the C compiler used by @code`jpm` is @code`cl.exe` , which is
+For Windows, the C compiler used by @code`jpm` is @code`cl.exe`, which is
 part of MSVC. You can get it with Visual Studio, or standalone with the C and C++
 Build Tools from Microsoft. You will then need to run @code`jpm build` in
 a Developer Command Prompt, or source @code`vcvars64.bat` in your shell to add
@@ -92,7 +92,7 @@ a Developer Command Prompt, or source @code`vcvars64.bat` in your shell to add
 ### Testing
 
 Once we have built our software, it is a good idea to test it to verify that it works
-on the current machine. @code`jpm test` will run all test scripts in the @code`test`
+on the current machine. @code`jpm test` will run all Janet scripts in the @code`test`
 directory of the project and return a non-zero exit code if any fail.
 
 ### Installing
@@ -101,8 +101,8 @@ Finally, once we have built our software and tested that it works, we can
 install it on our system. For an executable, this means copying it to the
 @code`bin` directory, and for libraries it means copying them to the global
 syspath. You can optionally install into any directory if you don't want to
-pollute your system or you don't have permission to write the directory
-where janet itself was installed.  You can specify the path to install modules
+pollute your system or you don't have permission to write to the directory
+where @code`janet` itself was installed.  You can specify the path to install modules
 to via the @code`--modpath` option, and the path to install binaries to with
 the @code`--binpath` option. These need to given before the subcommand
 @code`install`.
@@ -120,7 +120,7 @@ several rules, including @code`"install"`, @code`"build"`, @code`"clean"`, and
 @code`"test"`. These are a few of the rules that @code`jpm` expects @code`project.janet`
 to create when executed.
 
-### Declaring a Project
+### Declaring a project
 
 Use the @code`declare-project` as the first @code`declare-` macro
 towards the beginning of your @code`project.janet` file. You can also
@@ -136,12 +136,12 @@ dependencies on other Janet projects here.
   :dependencies ["https://github.com/janet-lang/json.git"])
 ```
 
-### Creating a Module
+### Creating a module
 
-A 100% janet library is the easiest kind of software to distribute in Janet.
-Since it does not need to be built, and installing it is simply moving
+A 100% Janet library is the easiest kind of software to distribute in Janet.
+Since it does not need to be built and since installing it means simply moving
 the files to a system directory, we only need to specify the files that
-comprise the library in @code`project.janet`
+comprise the library in @code`project.janet`.
 
 @codeblock[janet]```
 (declare-source
@@ -153,7 +153,7 @@ comprise the library in @code`project.janet`
 
 For information on writing modules, see @link[/docs/modules.html]{the modules docpage}.
 
-### Creating a Native Module
+### Creating a native module
 
 Once you have written your C code that defines your native module
 (see the @link[/capi/embedding.html]{embedding} page on how to do this), you
@@ -167,14 +167,14 @@ the native modules for you.
  :embedded ["extra-functions.janet"])
 ```
 
-This makes @code`jpm` create a native module called @code`mynative` when build
-is run, and the arguments should be pretty straight forward. The
+This makes @code`jpm` create a native module called @code`mynative` when @code`jpm build`
+is run, the arguments for which should be pretty straightforward. The
 @code`:embedded` argument is Janet source code that will be embedded as an array
 of bytes directly into the C source code. It is not recommended to use the
 @code`:embedded` argument, as one can simply create multiple artifacts, one for
 a pure C native module and one for Janet source code.
 
-### Creating an Executable
+### Creating an executable
 
 The declaration for an executable file is pretty simple.
 
@@ -187,12 +187,12 @@ The declaration for an executable file is pretty simple.
 @p{@code`jpm` is smart enough to figure out from the one entry file what libraries
     and other code your executable depends on, and bundles them into the final application
     for you. The final executable will be located at @code`build/myexec`, or @code`build\myexec.exe`
-    on windows.}
+    on Windows.}
 
 Also note that the entry of an executable file should look different than a
-normal janet script.  It should define a @code`main` function that can receive
+normal Janet script.  It should define a @code`main` function that can receive
 a variable number of parameters, the command-line arguments. It will be called
-as the entry to your executable.
+as the entry point to your executable.
 
 @codeblock[janet]```
 (import mylib1)
@@ -219,7 +219,7 @@ This has a number of benefits, but the largest is that we only include bytecode
 for the functions that our application uses. If we only use one function from
 a library of 1000 functions, our final executable will not include the bytecode
 for the other 999 functions (unless our one function references some of those
-        other functions, of course). This feature, called tree-shaking, only works
+other functions, of course). This feature, called tree-shaking, only works
 for Janet code. Native modules will be linked to the final executable statically
 in full if they are used at all. A native module is considered "used" if is imported
 at any time during @code`jpm build`. This may change, but it is currently the most reliable

--- a/content/docs/jpm.mdz
+++ b/content/docs/jpm.mdz
@@ -11,30 +11,30 @@ updated in step with Janet. @code`jpm` also works on Windows, Linux, and macOS
 so you don't need to write multiple build scripts and worry about platform
 quirks to make your scripts, binaries, and applications cross-platform.
 
-@p{
-@code`jpm`'s main functions are installing dependencies and building native Janet
-    modules, but it is meant to be used for much of the life-cycle for Janet
-    projects. Since Janet code doesn't usually need to
-    be compiled, you don't always need @code`jpm`, especially for scripts, but @code`jpm`
-    comes with some functionality that is difficult to duplicate, like compiling Janet source code
-    and all imported modules into a statically linked executable for distribution.
+@p{@code`jpm`'s main functions are installing dependencies and building native
+    Janet modules, but it is meant to be used for much of the life-cycle for
+    Janet projects. Since Janet code doesn't usually need to be compiled, you
+    don't always need @code`jpm`, especially for scripts, but @code`jpm` comes
+    with some functionality that is difficult to duplicate, like compiling Janet
+    source code and all imported modules into a statically linked executable for
+    distribution.
 }
 
 ## Glossary
 
-A self contained unit of Janet source code as recognized by @code`jpm` is
-called a project. A project is a directory containing a @code`project.janet`
-file, which contains build recipes. Often, a project will
-correspond to a single git repository, and contain a single library. However, a
-project's @code`project.janet` file can contain build recipes for as many
-libraries, native extensions, and executables as it wants. Each of these
-recipes builds an artifact. Artifacts are the output files that will either be
-distributed or installed on the end-user or developer's machine.
+A self contained unit of Janet source code as recognized by @code`jpm` is called
+a project. A project is a directory containing a @code`project.janet` file,
+which contains build recipes. Often, a project will correspond to a single git
+repository, and contain a single library. However, a project's
+@code`project.janet` file can contain build recipes for as many libraries,
+native extensions, and executables as it wants. Each of these recipes builds an
+artifact. Artifacts are the output files that will either be distributed or
+installed on the end-user or developer's machine.
 
 ## Building projects with @code`jpm`
 
-Once you have the project on your machine, building the
-various artifacts should be pretty simple.
+Once you have the project on your machine, building the various artifacts should
+be pretty simple.
 
 #### Global install
 
@@ -46,7 +46,8 @@ sudo jpm install
 ```
 
 \(On Windows, @code`sudo` is not required. Use of @code`sudo` on POSIX systems
-depends on whether you installed @code`janet` to a directory owned by the root user.)
+depends on whether you installed @code`janet` to a directory owned by the root
+user.)
 
 #### Local install
 
@@ -60,40 +61,41 @@ jpm install
 
 ### Dependencies
 
-@p{
-@code`jpm deps` is a command that installs Janet libraries that the project depends on recursively.
-    It will automatically fetch, build, and install all required dependencies for you.
-    As of August 2019, this only works with git, which you need to have installed on your
-    machine to install dependencies. If you don't have git you are free to manually
-    obtain the requisite dependencies and install them manually with @code`sudo jpm install`.
+@p{@code`jpm deps` is a command that installs Janet libraries that the project
+    depends on recursively.  It will automatically fetch, build, and install all
+    required dependencies for you.  As of August 2019, this only works with git,
+    which you need to have installed on your machine to install dependencies. If
+    you don't have git you are free to manually obtain the requisite
+    dependencies and install them manually with @code`sudo jpm install`.
 }
 
 ### Building
 
 Next, we use the @code`jpm build` command to build artifacts. All built
 artifacts will be created in the @code`build` subdirectory of the current
-project. Therefore, it is probably a good idea to exclude the @code`build` directory
-from source control. For building executables and native modules, you will need
-to have a C compiler on your PATH where you run @code`jpm build`. For POSIX
-systems, the compiler is @code`cc`.
+project. Therefore, it is probably a good idea to exclude the @code`build`
+directory from source control. For building executables and native modules, you
+will need to have a C compiler on your PATH where you run @code`jpm build`. For
+POSIX systems, the compiler is @code`cc`.
 
-If you make changes to the source code after building once, @code`jpm` will
-try to only rebuild what is needed on a rebuild. If this fails for any reason, you
+If you make changes to the source code after building once, @code`jpm` will try
+to only rebuild what is needed on a rebuild. If this fails for any reason, you
 can delete the entire build directory with @code`jpm clean` to reset things.
 
 #### Windows
 
-For Windows, the C compiler used by @code`jpm` is @code`cl.exe`, which is
-part of MSVC. You can get it with Visual Studio, or standalone with the C and C++
-Build Tools from Microsoft. You will then need to run @code`jpm build` in
-a Developer Command Prompt, or source @code`vcvars64.bat` in your shell to add
+For Windows, the C compiler used by @code`jpm` is @code`cl.exe`, which is part
+of MSVC. You can get it with Visual Studio, or standalone with the C and C++
+Build Tools from Microsoft. You will then need to run @code`jpm build` in a
+Developer Command Prompt, or source @code`vcvars64.bat` in your shell to add
 @code`cl.exe` to the PATH.
 
 ### Testing
 
-Once we have built our software, it is a good idea to test it to verify that it works
-on the current machine. @code`jpm test` will run all Janet scripts in the @code`test`
-directory of the project and return a non-zero exit code if any fail.
+Once we have built our software, it is a good idea to test it to verify that it
+works on the current machine. @code`jpm test` will run all Janet scripts in the
+@code`test` directory of the project and return a non-zero exit code if any
+fail.
 
 ### Installing
 
@@ -101,31 +103,31 @@ Finally, once we have built our software and tested that it works, we can
 install it on our system. For an executable, this means copying it to the
 @code`bin` directory, and for libraries it means copying them to the global
 syspath. You can optionally install into any directory if you don't want to
-pollute your system or you don't have permission to write to the directory
-where @code`janet` itself was installed.  You can specify the path to install modules
-to via the @code`--modpath` option, and the path to install binaries to with
-the @code`--binpath` option. These need to given before the subcommand
+pollute your system or you don't have permission to write to the directory where
+@code`janet` itself was installed.  You can specify the path to install modules
+to via the @code`--modpath` option, and the path to install binaries to with the
+@code`--binpath` option. These need to given before the subcommand
 @code`install`.
 
 ## The @code`project.janet` file
 
-To create your own software in Janet, it is a good idea to understand what
-the @code`project.janet` file is and how it defines rules for building, testing, and
-installing software. The code in
-@code`project.janet` is normal Janet source code that is run in a special environment.
+To create your own software in Janet, it is a good idea to understand what the
+@code`project.janet` file is and how it defines rules for building, testing, and
+installing software. The code in @code`project.janet` is normal Janet source
+code that is run in a special environment.
 
 A @code`project.janet` file is loaded by @code`jpm` and evaluated to create
-various recipes, or rules. For example, @code`declare-project` creates
-several rules, including @code`"install"`, @code`"build"`, @code`"clean"`, and
-@code`"test"`. These are a few of the rules that @code`jpm` expects @code`project.janet`
-to create when executed.
+various recipes, or rules. For example, @code`declare-project` creates several
+rules, including @code`"install"`, @code`"build"`, @code`"clean"`, and
+@code`"test"`. These are a few of the rules that @code`jpm` expects
+@code`project.janet` to create when executed.
 
 ### Declaring a project
 
-Use the @code`declare-project` as the first @code`declare-` macro
-towards the beginning of your @code`project.janet` file. You can also
-pass in any metadata about your project that you want, and add
-dependencies on other Janet projects here.
+Use the @code`declare-project` as the first @code`declare-` macro towards the
+beginning of your @code`project.janet` file. You can also pass in any metadata
+about your project that you want, and add dependencies on other Janet projects
+here.
 
 @codeblock[janet]```
 (declare-project
@@ -140,8 +142,8 @@ dependencies on other Janet projects here.
 
 A 100% Janet library is the easiest kind of software to distribute in Janet.
 Since it does not need to be built and since installing it means simply moving
-the files to a system directory, we only need to specify the files that
-comprise the library in @code`project.janet`.
+the files to a system directory, we only need to specify the files that comprise
+the library in @code`project.janet`.
 
 @codeblock[janet]```
 (declare-source
@@ -155,10 +157,10 @@ For information on writing modules, see @link[/docs/modules.html]{the modules do
 
 ### Creating a native module
 
-Once you have written your C code that defines your native module
-(see the @link[/capi/embedding.html]{embedding} page on how to do this), you
-must declare it in @code`project.janet` in order for @code`jpm` to build
-the native modules for you.
+Once you have written your C code that defines your native module (see the
+@link[/capi/embedding.html]{embedding} page on how to do this), you must declare
+it in @code`project.janet` in order for @code`jpm` to build the native modules
+for you.
 
 @codeblock[janet]```
 (declare-native
@@ -167,12 +169,13 @@ the native modules for you.
  :embedded ["extra-functions.janet"])
 ```
 
-This makes @code`jpm` create a native module called @code`mynative` when @code`jpm build`
-is run, the arguments for which should be pretty straightforward. The
-@code`:embedded` argument is Janet source code that will be embedded as an array
-of bytes directly into the C source code. It is not recommended to use the
-@code`:embedded` argument, as one can simply create multiple artifacts, one for
-a pure C native module and one for Janet source code.
+This makes @code`jpm` create a native module called @code`mynative` when
+@code`jpm build` is run, the arguments for which should be pretty
+straightforward. The @code`:embedded` argument is Janet source code that will be
+embedded as an array of bytes directly into the C source code. It is not
+recommended to use the @code`:embedded` argument, as one can simply create
+multiple artifacts, one for a pure C native module and one for Janet source
+code.
 
 ### Creating an executable
 
@@ -184,15 +187,15 @@ The declaration for an executable file is pretty simple.
  :entry "main.janet")
 ```
 
-@p{@code`jpm` is smart enough to figure out from the one entry file what libraries
-    and other code your executable depends on, and bundles them into the final application
-    for you. The final executable will be located at @code`build/myexec`, or @code`build\myexec.exe`
-    on Windows.}
+@p{@code`jpm` is smart enough to figure out from the one entry file what
+    libraries and other code your executable depends on, and bundles them into
+    the final application for you. The final executable will be located at
+    @code`build/myexec`, or @code`build\myexec.exe` on Windows.}
 
 Also note that the entry of an executable file should look different than a
-normal Janet script.  It should define a @code`main` function that can receive
-a variable number of parameters, the command-line arguments. It will be called
-as the entry point to your executable.
+normal Janet script.  It should define a @code`main` function that can receive a
+variable number of parameters, the command-line arguments. It will be called as
+the entry point to your executable.
 
 @codeblock[janet]```
 (import mylib1)
@@ -210,24 +213,27 @@ as the entry point to your executable.
 
 It's important to remember that code at the top level will run when you invoke
 @code`jpm build`, not at executable runtime. This is because in order to create
-the executable, we marshal the @code`main` function of the app and write it
-to an image. In order to create the main function, we need to actually compile
-and run everything that it references, in the above case @code`mylib1` and
+the executable, we marshal the @code`main` function of the app and write it to
+an image. In order to create the main function, we need to actually compile and
+run everything that it references, in the above case @code`mylib1` and
 @code`mylib2`.
 
 This has a number of benefits, but the largest is that we only include bytecode
-for the functions that our application uses. If we only use one function from
-a library of 1000 functions, our final executable will not include the bytecode
+for the functions that our application uses. If we only use one function from a
+library of 1000 functions, our final executable will not include the bytecode
 for the other 999 functions (unless our one function references some of those
 other functions, of course). This feature, called tree-shaking, only works
 for Janet code. Native modules will be linked to the final executable statically
-in full if they are used at all. A native module is considered "used" if is imported
-at any time during @code`jpm build`. This may change, but it is currently the most reliable
-way to check if a native modules needs to be linked into the final executable.
+in full if they are used at all. A native module is considered "used" if is
+imported at any time during @code`jpm build`. This may change, but it is
+currently the most reliable way to check if a native modules needs to be linked
+into the final executable.
 
-There are some limitations to this approach. Any dynamically required modules will not
-always be linked into the final executable. If @code`require` or @code`import` is not called
-during @code`jpm build`, then the code will not be linked into the executable. The module
-can still be required if it is available at runtime, though.
+There are some limitations to this approach. Any dynamically required modules
+will not always be linked into the final executable. If @code`require` or
+@code`import` is not called during @code`jpm build`, then the code will not be
+linked into the executable. The module can still be required if it is available
+at runtime, though.
 
-For an example Janet executable built with @code`jpm`, see @link[https://github.com/bakpakin/littleserver][https://github.com/bakpakin/littleserver].
+For an example Janet executable built with @code`jpm`, see
+@link[https://github.com/bakpakin/littleserver][https://github.com/bakpakin/littleserver].

--- a/content/docs/loop.mdz
+++ b/content/docs/loop.mdz
@@ -5,25 +5,25 @@
 
 A very common and essential operation in all programming is looping. Most
 languages support looping of some kind, either with explicit loops or recursion.
-Janet supports both recursion and a primitive @code[while] loop. While recursion is
-useful in many cases, sometimes it is more convenient to use an explicit loop to
-iterate over a collection like an array.
+Janet supports both recursion and a primitive @code[while] loop. While recursion
+is useful in many cases, sometimes it is more convenient to use an explicit loop
+to iterate over a collection like an array.
 
 ## Example 1: Iterating a range
 
-Suppose you want to calculate the sum of the first 10 natural numbers
-0 through 9. There are many ways to carry out this explicit calculation.
-A succinct way in Janet is:
+Suppose you want to calculate the sum of the first 10 natural numbers 0 through
+9. There are many ways to carry out this explicit calculation.  A succinct way
+in Janet is:
 
 @codeblock[janet]```
 (+ ;(range 10))
 ```
 
-We will limit ourselves however to using explicit looping and no functions
-like @code[(range n)] which generate a list of natural numbers for us.
+We will limit ourselves however to using explicit looping and no functions like
+@code[(range n)] which generate a list of natural numbers for us.
 
-For our first version, we will use only the @code`while` form to iterate, similar
-to how one might sum natural numbers in a language such as C.
+For our first version, we will use only the @code`while` form to iterate,
+similar to how one might sum natural numbers in a language such as C.
 
 @codeblock[janet]```
 (var sum 0)
@@ -34,15 +34,15 @@ to how one might sum natural numbers in a language such as C.
 (print sum) # prints 45
 ```
 
-This is a very imperative program, and it is not the best way to write this in Janet.
-We are manually updating a counter @code[i] in a loop. Using the macros @code[+=] and @code[++], this
-style code is similar in density to C code.
-It is recommended to instead use either macros (such as the @code`loop` or @code`for` macros) or a functional
-style in Janet.
+This is a very imperative program, and it is not the best way to write this in
+Janet.  We are manually updating a counter @code[i] in a loop. Using the macros
+@code[+=] and @code[++], this style code is similar in density to C code.  It is
+recommended to instead use either macros (such as the @code`loop` or @code`for`
+macros) or a functional style in Janet.
 
-Since this is such a common pattern, Janet has a macro for this exact purpose. The
-@code[(for x start end body)] form captures this behavior of incrementing a counter
-in a loop.
+Since this is such a common pattern, Janet has a macro for this exact purpose.
+The @code[(for x start end body)] form captures this behavior of incrementing a
+counter in a loop.
 
 @codeblock[janet]```
 (var sum 0)
@@ -50,10 +50,11 @@ in a loop.
 (print sum) # prints 45
 ```
 
-We have completely wrapped the imperative counter in a macro. The @code`for` macro, while not
-very flexible, is very terse and covers a common case of iteration: iterating over an integer range.
-The @code`for` macro will be expanded to something very similar to our original
-version with a @code`while` loop.
+We have completely wrapped the imperative counter in a macro. The @code`for`
+macro, while not very flexible, is very terse and covers a common case of
+iteration: iterating over an integer range.  The @code`for` macro will be
+expanded to something very similar to our original version with a @code`while`
+loop.
 
 We can do something similar with the more flexible @code`loop` macro.
 
@@ -63,9 +64,9 @@ We can do something similar with the more flexible @code`loop` macro.
 (print sum) # prints 45
 ```
 
-This is slightly more verbose than the @code`for` macro, but can be more easily extended.
-Let's say that we wanted to only count even numbers towards the sum. We can do this
-easily with the @code`loop` macro.
+This is slightly more verbose than the @code`for` macro, but can be more easily
+extended.  Let's say that we wanted to only count even numbers towards the sum.
+We can do this easily with the @code`loop` macro.
 
 @codeblock[janet]```
 (var sum 0)
@@ -73,21 +74,22 @@ easily with the @code`loop` macro.
 (print sum) # prints 20
 ```
 
-The @code`loop` macro has several verbs (@code`:range`) and modifiers (@code`:when`)
-that let the programmer more easily generate common looping idioms. The @code`loop` macro
-is similar to the Common Lips @code`loop` macro, but smaller in scope and with a much
-simpler syntax. As with the @code`for` macro, the @code`loop` macro expands to similar
-code as our original @code`while` expression.
+The @code`loop` macro has several verbs (@code`:range`) and modifiers
+(@code`:when`) that let the programmer more easily generate common looping
+idioms. The @code`loop` macro is similar to the Common Lips @code`loop` macro,
+but smaller in scope and with a much simpler syntax. As with the @code`for`
+macro, the @code`loop` macro expands to similar code as our original
+@code`while` expression.
 
 ## Example 2: Iterating over an indexed data structure
 
-Another common usage for iteration in any language is iterating over the items in
-a data structure, like items in an array, characters in a string, or key-value
-pairs in a table.
+Another common usage for iteration in any language is iterating over the items
+in a data structure, like items in an array, characters in a string, or
+key-value pairs in a table.
 
-Say we have an array of names that we want to print out. We will
-again start with a simple @code`while` loop which we will refine into
-more idiomatic expressions.
+Say we have an array of names that we want to print out. We will again start
+with a simple @code`while` loop which we will refine into more idiomatic
+expressions.
 
 First, we will define our array of names:
 
@@ -100,8 +102,8 @@ First, we will define our array of names:
    "Harriet Tubman"])
 ```
 
-With our array of names, we can use a @code`while` loop to iterate through the indices of names, get the
-values, and then print them.
+With our array of names, we can use a @code`while` loop to iterate through the
+indices of names, get the values, and then print them.
 
 @codeblock[janet]```
 (var i 0)
@@ -111,41 +113,43 @@ values, and then print them.
     (++ i))
 ```
 
-This is rather verbose. Janet provides the @code[each] macro for iterating through the items in a tuple or
-array, or the bytes in a buffer, symbol, or string.
+This is rather verbose. Janet provides the @code[each] macro for iterating
+through the items in a tuple or array, or the bytes in a buffer, symbol, or
+string.
 
 @codeblock[janet]```
 (each name names (print name))
 ```
 
-We can also use the @code[loop] macro for this case as well using the @code[:in] verb.
+We can also use the @code[loop] macro for this case as well using the @code[:in]
+verb.
 
 @codeblock[janet]```
 (loop [name :in names] (print name))
 ```
 
-Lastly, we can use the @code`map` function to apply a function over each value in the
-array.
+Lastly, we can use the @code`map` function to apply a function over each value
+in the array.
 
 @codeblock[janet]```
 (map print names)
 ```
 
-The @code`each` macro is actually more flexible than the normal loop, as it is able to iterate over
-data structures that are not like arrays. For example, @code`each` will iterate over the values in a
-table.
+The @code`each` macro is actually more flexible than the normal loop, as it is
+able to iterate over data structures that are not like arrays. For example,
+@code`each` will iterate over the values in a table.
 
 ## Example 3: Iterating a dictionary
 
 In the previous example, we iterated over the values in an array. Another common
-use of looping in a Janet program is iterating over the keys or values in a table.
-We cannot use the same method as iterating over an array because a table or struct does
-not contain a known integer range of keys. Instead we rely on a function @code[next], which allows
-us to visit each of the keys in a struct or table. Note that iterating over a table will not
-visit the prototype table.
+use of looping in a Janet program is iterating over the keys or values in a
+table.  We cannot use the same method as iterating over an array because a table
+or struct does not contain a known integer range of keys. Instead we rely on a
+function @code[next], which allows us to visit each of the keys in a struct or
+table. Note that iterating over a table will not visit the prototype table.
 
-As an example, let's iterate over a table of letters to a word that starts with that letter. We
-will print out the words to our simple children's book.
+As an example, let's iterate over a table of letters to a word that starts with
+that letter. We will print out the words to our simple children's book.
 
 @codeblock[janet]```
 (def alphabook
@@ -156,10 +160,11 @@ will print out the words to our simple children's book.
     "E" "Elephant"})
 ```
 
-As before, we can evaluate this loop using only a @code`while` loop and the @code[next] function. The
-@code `next` function is the primary way to iterate in Janet, and is overloaded to
-support all iterable types. Given a data structure and a key, it returns the next key in
-the data structure. If there are no more keys left, it returns @code`nil`.
+As before, we can evaluate this loop using only a @code`while` loop and the
+@code[next] function. The @code `next` function is the primary way to iterate in
+Janet, and is overloaded to support all iterable types. Given a data structure
+and a key, it returns the next key in the data structure. If there are no more
+keys left, it returns @code`nil`.
 
 @codeblock[janet]```
 (var key (next alphabook nil))
@@ -168,31 +173,33 @@ the data structure. If there are no more keys left, it returns @code`nil`.
   (set key (next alphabook key)))
 ```
 
-However, we can do better than this with the @code`loop` macro using the @code[:pairs] or @code[:keys] verbs.
+However, we can do better than this with the @code`loop` macro using the
+@code[:pairs] or @code[:keys] verbs.
 
 @codeblock[janet]```
 (loop [[letter word] :pairs alphabook]
   (print letter " is for " word))
 ```
 
-Using the @code[:keys] verb and shorthand notation for indexing
-a data structure:
+Using the @code[:keys] verb and shorthand notation for indexing a data
+structure:
 
 @codeblock[janet]```
 (loop [letter :keys alphabook]
   (print letter " is for " (alphabook letter)))
 ```
 
-As an alternative to the @code`loop` macro here, we can also use the macros @code`eachk` and
-@code`eachp`, which behave like @code`each` but @code`loop` over the keys of a data structure and
-the key-value pairs in a data structure respectively.
+As an alternative to the @code`loop` macro here, we can also use the macros
+@code`eachk` and @code`eachp`, which behave like @code`each` but @code`loop`
+over the keys of a data structure and the key-value pairs in a data structure
+respectively.
 
-Data structures like tables and structs can be called like functions that look up their
-arguments. This allows for writing shorter code than what
-is possible with @code[(get alphabook letter)].
+Data structures like tables and structs can be called like functions that look
+up their arguments. This allows for writing shorter code than what is possible
+with @code[(get alphabook letter)].
 
-We can also use the core library functions @code[keys] and @code[pairs] to get arrays of the keys and
-pairs respectively of the alphabook.
+We can also use the core library functions @code[keys] and @code[pairs] to get
+arrays of the keys and pairs respectively of the alphabook.
 
 @codeblock[janet]```
 (loop [[letter word] :in (pairs alphabook)]
@@ -202,7 +209,7 @@ pairs respectively of the alphabook.
   (print letter " is for " (alphabook letter)))
 ```
 
-Notice that iteration through the table is in no particular order. Iterating
-the keys of a table or struct guarantees no order. If you want to
-iterate in a specific order, use a different data structure or
-the @code[(sort indexed)] function.
+Notice that iteration through the table is in no particular order. Iterating the
+keys of a table or struct guarantees no order. If you want to iterate in a
+specific order, use a different data structure or the @code[(sort indexed)]
+function.

--- a/content/docs/loop.mdz
+++ b/content/docs/loop.mdz
@@ -6,14 +6,14 @@
 A very common and essential operation in all programming is looping. Most
 languages support looping of some kind, either with explicit loops or recursion.
 Janet supports both recursion and a primitive @code[while] loop. While recursion is
-useful in many cases, sometimes is more convenient to use a explicit loop to
+useful in many cases, sometimes it is more convenient to use an explicit loop to
 iterate over a collection like an array.
 
-## An Example - Iterating a Range
+## Example 1: Iterating a range
 
 Suppose you want to calculate the sum of the first 10 natural numbers
-0 through 9. There are many ways to carry out this explicit calculation
-even with taking shortcuts. A succinct way in Janet is
+0 through 9. There are many ways to carry out this explicit calculation.
+A succinct way in Janet is:
 
 @codeblock[janet]```
 (+ ;(range 10))
@@ -22,7 +22,7 @@ even with taking shortcuts. A succinct way in Janet is
 We will limit ourselves however to using explicit looping and no functions
 like @code[(range n)] which generate a list of natural numbers for us.
 
-For our first version, we will use only the while form to iterate, similar
+For our first version, we will use only the @code`while` form to iterate, similar
 to how one might sum natural numbers in a language such as C.
 
 @codeblock[janet]```
@@ -37,11 +37,11 @@ to how one might sum natural numbers in a language such as C.
 This is a very imperative program, and it is not the best way to write this in Janet.
 We are manually updating a counter @code[i] in a loop. Using the macros @code[+=] and @code[++], this
 style code is similar in density to C code.
-It is recommended to use either macros (such as the @code`loop` or @code`for` macros) or a functional
+It is recommended to instead use either macros (such as the @code`loop` or @code`for` macros) or a functional
 style in Janet.
 
 Since this is such a common pattern, Janet has a macro for this exact purpose. The
-@code[(for x start end body)] captures exactly this behavior of incrementing a counter
+@code[(for x start end body)] form captures this behavior of incrementing a counter
 in a loop.
 
 @codeblock[janet]```
@@ -50,11 +50,12 @@ in a loop.
 (print sum) # prints 45
 ```
 
-We have completely wrapped the imperative counter in a macro. The for macro, while not
-very flexible, is very terse and covers a common case of iteration, iterating over an integer range. The for macro will be expanded to something very similar to our original
-version with a while loop.
+We have completely wrapped the imperative counter in a macro. The @code`for` macro, while not
+very flexible, is very terse and covers a common case of iteration: iterating over an integer range.
+The @code`for` macro will be expanded to something very similar to our original
+version with a @code`while` loop.
 
-We can do something similar with the more flexible `loop` macro.
+We can do something similar with the more flexible @code`loop` macro.
 
 @codeblock[janet]```
 (var sum 0)
@@ -62,9 +63,9 @@ We can do something similar with the more flexible `loop` macro.
 (print sum) # prints 45
 ```
 
-This is slightly more verbose than the for macro, but can be more easily extended.
+This is slightly more verbose than the @code`for` macro, but can be more easily extended.
 Let's say that we wanted to only count even numbers towards the sum. We can do this
-easily with the loop macro.
+easily with the @code`loop` macro.
 
 @codeblock[janet]```
 (var sum 0)
@@ -72,23 +73,23 @@ easily with the loop macro.
 (print sum) # prints 20
 ```
 
-The loop macro has several verbs (:range) and modifiers (:when) that let
-the programmer more easily generate common looping idioms. The loop macro
-is similar to the Common Lips loop macro, but smaller in scope and with a much
-simpler syntax. As with the `for` macro, the loop macro expands to similar
-code as our original while expression.
+The @code`loop` macro has several verbs (@code`:range`) and modifiers (@code`:when`)
+that let the programmer more easily generate common looping idioms. The @code`loop` macro
+is similar to the Common Lips @code`loop` macro, but smaller in scope and with a much
+simpler syntax. As with the @code`for` macro, the @code`loop` macro expands to similar
+code as our original @code`while` expression.
 
-## Another Example - Iterating an Indexed Data Structure
+## Example 2: Iterating over an indexed data structure
 
 Another common usage for iteration in any language is iterating over the items in
-some data structure, like items in an array, characters in a string, or key value
+a data structure, like items in an array, characters in a string, or key-value
 pairs in a table.
 
 Say we have an array of names that we want to print out. We will
-again start with a simple while loop which we will refine into
+again start with a simple @code`while` loop which we will refine into
 more idiomatic expressions.
 
-First, we will define our array of names
+First, we will define our array of names:
 
 @codeblock[janet]```
 (def names
@@ -99,8 +100,8 @@ First, we will define our array of names
    "Harriet Tubman"])
 ```
 
-With our array of names, we can use a while loop to iterate through the indices of names, get the
-values, and the print them.
+With our array of names, we can use a @code`while` loop to iterate through the indices of names, get the
+values, and then print them.
 
 @codeblock[janet]```
 (var i 0)
@@ -110,7 +111,7 @@ values, and the print them.
     (++ i))
 ```
 
-This is rather verbose. janet provides the @code[each] macro for iterating through the items in a tuple or
+This is rather verbose. Janet provides the @code[each] macro for iterating through the items in a tuple or
 array, or the bytes in a buffer, symbol, or string.
 
 @codeblock[janet]```
@@ -134,7 +135,7 @@ The @code`each` macro is actually more flexible than the normal loop, as it is a
 data structures that are not like arrays. For example, @code`each` will iterate over the values in a
 table.
 
-## Iterating a Dictionary
+## Example 3: Iterating a dictionary
 
 In the previous example, we iterated over the values in an array. Another common
 use of looping in a Janet program is iterating over the keys or values in a table.
@@ -143,7 +144,7 @@ not contain a known integer range of keys. Instead we rely on a function @code[n
 us to visit each of the keys in a struct or table. Note that iterating over a table will not
 visit the prototype table.
 
-As an example, lets iterate over a table of letters to a word that starts with that letter. We
+As an example, let's iterate over a table of letters to a word that starts with that letter. We
 will print out the words to our simple children's book.
 
 @codeblock[janet]```
@@ -155,10 +156,10 @@ will print out the words to our simple children's book.
     "E" "Elephant"})
 ```
 
-As before, we can evaluate this loop using only a while loop and the @code[next] function. The
+As before, we can evaluate this loop using only a @code`while` loop and the @code[next] function. The
 @code `next` function is the primary way to iterate in Janet, and is overloaded to
 support all iterable types. Given a data structure and a key, it returns the next key in
-the data structure. If there are no more keys left, it returns nil.
+the data structure. If there are no more keys left, it returns @code`nil`.
 
 @codeblock[janet]```
 (var key (next alphabook nil))
@@ -167,7 +168,7 @@ the data structure. If there are no more keys left, it returns nil.
   (set key (next alphabook key)))
 ```
 
-However, we can do better than this with the loop macro using the @code[:pairs] or @code[:keys] verbs.
+However, we can do better than this with the @code`loop` macro using the @code[:pairs] or @code[:keys] verbs.
 
 @codeblock[janet]```
 (loop [[letter word] :pairs alphabook]
@@ -175,15 +176,15 @@ However, we can do better than this with the loop macro using the @code[:pairs] 
 ```
 
 Using the @code[:keys] verb and shorthand notation for indexing
-a data structure.
+a data structure:
 
 @codeblock[janet]```
 (loop [letter :keys alphabook]
   (print letter " is for " (alphabook letter)))
 ```
 
-As an alternative to the loop macro here, we can also use the macros @code`eachk` and
-@code`eachp`, which behave like @code`each` but loop over the keys of a data structure and
+As an alternative to the @code`loop` macro here, we can also use the macros @code`eachk` and
+@code`eachp`, which behave like @code`each` but @code`loop` over the keys of a data structure and
 the key-value pairs in a data structure respectively.
 
 Data structures like tables and structs can be called like functions that look up their

--- a/content/docs/macros.mdz
+++ b/content/docs/macros.mdz
@@ -3,7 +3,7 @@
  :order 9}
 ---
 
-Janet supports macros, routines that take code as input and return transformed code
+Janet supports macros: routines that take code as input and return transformed code
 as output. A macro is like a function, but transforms
 the code itself rather than data, so it is more flexible in what it can do than a function.
 Macros let you extend the syntax of the language itself.
@@ -33,7 +33,7 @@ We could write such a macro like so:
 There are a couple of issues with this macro, but it will work for simple functions
 quite well.
 
-The first issue is that our defn1 macro can't define functions with multiple expressions
+The first issue is that our @code`defn1` macro can't define functions with multiple expressions
 in the body. We can make the macro variadic, just like a function. Here is a second version
 of this macro:
 
@@ -42,10 +42,12 @@ of this macro:
  (tuple 'def name (apply tuple 'fn name args body)))
 ```)
 
-Great! Now we can define functions with multiple elements in the body. We can still improve this
-macro even more though. First, we can add a docstring to it. If someone is using the function later,
-they can use @code[(doc defn3)] to get a description of the function. Next, we can rewrite the macro
-using janet's builtin quasiquoting facilities.
+Great! Now we can define functions with multiple elements in the body.
+
+We can still improve this macro even more though. First, we can add a docstring
+to it. If someone is using the function later, they can use @code[(doc defn3)]
+to get a description of the function. Next, we can rewrite the macro using
+Janet's builtin quasiquoting facilities.
 
 @codeblock[janet](```
 (defmacro defn3
@@ -58,12 +60,12 @@ This is functionally identical to our previous version @code[defn2], but written
 a way that the macro output is more clear. The leading tilde @code[~] is shorthand for the
 @code[(quasiquote x)] special form, which is like @code[(quote x)] except we can unquote
 expressions inside it. The comma in front of @code[name] and @code[args] is an unquote, which
-allows us to put a value in the quasiquote. Without the unquote, the symbol \'name\'
+allows us to put a value in the quasiquote. Without the unquote, the symbol @code`name`
 would be put in the returned tuple, and every function we defined
-would be called \'name\'!
+would be called @code`name`!
 
-Similar to name, we must also unquote body. However, a normal unquote doesn't work.
-See what happens if we use a normal unquote for body as well.
+Similar to @code`name`, we must also unquote @code`body`. However, a normal unquote doesn't work.
+See what happens if we use a normal unquote for @code`body` as well.
 
 @codeblock[janet](```
 (def name 'myfunction)
@@ -76,8 +78,8 @@ See what happens if we use a normal unquote for body as well.
 
 There is an extra set of parentheses around the body of our function! We don't
 want to put the body @strong{inside} the form @code[(fn args ...)], we want to @strong{splice} it
-into the form. Luckily, janet has the @code[(splice x)] special form for this purpose,
-and a shorthand for it, the ; character.
+into the form. Luckily, Janet has the @code[(splice x)] special form for this purpose,
+and a shorthand for it, the @code`;` character.
 When combined with the unquote special, we get the desired output:
 
 @codeblock[janet](```
@@ -97,9 +99,9 @@ this could be written as a function, consider the following macro:
  ~(if (> ,x ,y) ,x ,y))
 ```)
 
-This almost works, but will evaluate both x and y twice. This is because both show up
+This almost works, but will evaluate both @code`x` and @code`y` twice. This is because both show up
 in the macro twice. For example, @code[(max1 (do (print 1) 1) (do (print 2) 2))] will
-print both 1 and 2 twice, which is surprising to a user of this macro.
+print both 1 and 2 twice, which would be surprising to a user of this macro.
 
 We can do better:
 
@@ -120,20 +122,20 @@ What happens in the following code?
 (max2 8 (+ x 4))
 ```)
 
-We want the max to be 14, but this will actually evaluate to 12! This can be understood
-if we expand the macro. You can expand a macro once in janet using the @code[(macex1 x)] function.
-(To expand macros until there are no macros left to expand, use @code[(macex x)]. Be careful,
- janet has many macros, so the full expansion may be almost unreadable).
+We want the maximum to be 14, but this will actually evaluate to 12! This can be understood
+if we expand the macro. You can expand a macro once in Janet using the @code[(macex1 x)] function.
+(To expand macros until there are no macros left to expand, use @code[(macex x)]. Be careful:
+ Janet has many macros, so the full expansion may be almost unreadable).
 
 @codeblock[janet](```
 (macex1 '(max2 8 (+ x 4)))
 # -> (let (x 8 y (+ x 4)) (if (> x y) x y))
 ```)
 
-After expansion, y wrongly refers to the x inside the macro (which is bound to 8) rather than the x defined
-to be 10. The problem is the reuse of the symbol x inside the macro, which overshadowed the original
-binding. This problem is called the @link[https://en.wikipedia.org/wiki/Hygienic_macro#The_hygiene_problem]{hygiene problem} which is well known in many programming languages. Some languages provide
-complicated solutions to this problem, but Janet opts for a much simpler, if not primitive solution.
+After expansion, @code`y` wrongly refers to the @code`x` inside the macro (which
+is bound to 8) rather than the @code`x` defined to be 10. The problem is the reuse of the symbol @code`x` inside the macro, which overshadowed the original
+binding. This problem is called the @link[https://en.wikipedia.org/wiki/Hygienic_macro#The_hygiene_problem]{hygiene problem} and is well known in many programming languages. Some languages provide
+complicated solutions to this problem, but Janet opts for a much simpler&mdash;if not primitive&mdash;solution.
 
 Janet provides a general solution to this problem in terms of the @code[(gensym)] function, which returns
 a symbol which is guaranteed to be unique and not collide with any symbols defined previously. We can define

--- a/content/docs/macros.mdz
+++ b/content/docs/macros.mdz
@@ -3,15 +3,16 @@
  :order 9}
 ---
 
-Janet supports macros: routines that take code as input and return transformed code
-as output. A macro is like a function, but transforms
-the code itself rather than data, so it is more flexible in what it can do than a function.
+Janet supports macros: routines that take code as input and return transformed
+code as output. A macro is like a function, but transforms the code itself
+rather than data, so it is more flexible in what it can do than a function.
 Macros let you extend the syntax of the language itself.
 
-You have seen some macros already. The @code[let], @code[loop], and @code[defn] forms are macros. When the compiler
-sees a macro, it evaluates the macro and then compiles the result. We say the macro has been
-@strong{expanded} after the compiler evaluates it. A simple version of the @code[defn] macro can
-be thought of as transforming code of the form
+You have seen some macros already. The @code[let], @code[loop], and @code[defn]
+forms are macros. When the compiler sees a macro, it evaluates the macro and
+then compiles the result. We say the macro has been @strong{expanded} after the
+compiler evaluates it. A simple version of the @code[defn] macro can be thought
+of as transforming code of the form
 
 @codeblock[janet](```
 (defn1 myfun [x] body)
@@ -30,12 +31,12 @@ We could write such a macro like so:
  (tuple 'def name (tuple 'fn name args body)))
 ```)
 
-There are a couple of issues with this macro, but it will work for simple functions
-quite well.
+There are a couple of issues with this macro, but it will work for simple
+functions quite well.
 
-The first issue is that our @code`defn1` macro can't define functions with multiple expressions
-in the body. We can make the macro variadic, just like a function. Here is a second version
-of this macro:
+The first issue is that our @code`defn1` macro can't define functions with
+multiple expressions in the body. We can make the macro variadic, just like a
+function. Here is a second version of this macro:
 
 @codeblock[janet](```
 (defmacro defn2 [name args & body]
@@ -56,16 +57,17 @@ Janet's builtin quasiquoting facilities.
  ~(def ,name (fn ,name ,args ,;body)))
 ```)
 
-This is functionally identical to our previous version @code[defn2], but written in such
-a way that the macro output is more clear. The leading tilde @code[~] is shorthand for the
-@code[(quasiquote x)] special form, which is like @code[(quote x)] except we can unquote
-expressions inside it. The comma in front of @code[name] and @code[args] is an unquote, which
-allows us to put a value in the quasiquote. Without the unquote, the symbol @code`name`
-would be put in the returned tuple, and every function we defined
-would be called @code`name`!
+This is functionally identical to our previous version @code[defn2], but written
+in such a way that the macro output is more clear. The leading tilde @code[~] is
+shorthand for the @code[(quasiquote x)] special form, which is like @code[(quote
+x)] except we can unquote expressions inside it. The comma in front of
+@code[name] and @code[args] is an unquote, which allows us to put a value in the
+quasiquote. Without the unquote, the symbol @code`name` would be put in the
+returned tuple, and every function we defined would be called @code`name`!
 
-Similar to @code`name`, we must also unquote @code`body`. However, a normal unquote doesn't work.
-See what happens if we use a normal unquote for @code`body` as well.
+Similar to @code`name`, we must also unquote @code`body`. However, a normal
+unquote doesn't work.  See what happens if we use a normal unquote for
+@code`body` as well.
 
 @codeblock[janet](```
 (def name 'myfunction)
@@ -77,9 +79,9 @@ See what happens if we use a normal unquote for @code`body` as well.
 ```)
 
 There is an extra set of parentheses around the body of our function! We don't
-want to put the body @strong{inside} the form @code[(fn args ...)], we want to @strong{splice} it
-into the form. Luckily, Janet has the @code[(splice x)] special form for this purpose,
-and a shorthand for it, the @code`;` character.
+want to put the body @strong{inside} the form @code[(fn args ...)], we want to
+@strong{splice} it into the form. Luckily, Janet has the @code[(splice x)]
+special form for this purpose, and a shorthand for it, the @code`;` character.
 When combined with the unquote special, we get the desired output:
 
 @codeblock[janet](```
@@ -89,8 +91,8 @@ When combined with the unquote special, we get the desired output:
 
 ## Hygiene
 
-Sometimes when we write macros, we must generate symbols for local bindings. Ignoring that
-this could be written as a function, consider the following macro:
+Sometimes when we write macros, we must generate symbols for local bindings.
+Ignoring that this could be written as a function, consider the following macro:
 
 @codeblock[janet](```
 (defmacro max1
@@ -99,9 +101,10 @@ this could be written as a function, consider the following macro:
  ~(if (> ,x ,y) ,x ,y))
 ```)
 
-This almost works, but will evaluate both @code`x` and @code`y` twice. This is because both show up
-in the macro twice. For example, @code[(max1 (do (print 1) 1) (do (print 2) 2))] will
-print both 1 and 2 twice, which would be surprising to a user of this macro.
+This almost works, but will evaluate both @code`x` and @code`y` twice. This is
+because both show up in the macro twice. For example, @code[(max1 (do (print 1)
+1) (do (print 2) 2))] will print both 1 and 2 twice, which would be surprising
+to a user of this macro.
 
 We can do better:
 
@@ -114,18 +117,19 @@ We can do better:
     (if (> x y) x y)))
 ```)
 
-Now we have no double evaluation problem! But we now have an even more subtle problem.
-What happens in the following code?
+Now we have no double evaluation problem! But we now have an even more subtle
+problem.  What happens in the following code?
 
 @codeblock[janet](```
 (def x 10)
 (max2 8 (+ x 4))
 ```)
 
-We want the maximum to be 14, but this will actually evaluate to 12! This can be understood
-if we expand the macro. You can expand a macro once in Janet using the @code[(macex1 x)] function.
-(To expand macros until there are no macros left to expand, use @code[(macex x)]. Be careful:
- Janet has many macros, so the full expansion may be almost unreadable).
+We want the maximum to be 14, but this will actually evaluate to 12! This can be
+understood if we expand the macro. You can expand a macro once in Janet using
+the @code[(macex1 x)] function.  (To expand macros until there are no macros
+left to expand, use @code[(macex x)]. Be careful: Janet has many macros, so the
+full expansion may be almost unreadable).
 
 @codeblock[janet](```
 (macex1 '(max2 8 (+ x 4)))
@@ -133,13 +137,18 @@ if we expand the macro. You can expand a macro once in Janet using the @code[(ma
 ```)
 
 After expansion, @code`y` wrongly refers to the @code`x` inside the macro (which
-is bound to 8) rather than the @code`x` defined to be 10. The problem is the reuse of the symbol @code`x` inside the macro, which overshadowed the original
-binding. This problem is called the @link[https://en.wikipedia.org/wiki/Hygienic_macro#The_hygiene_problem]{hygiene problem} and is well known in many programming languages. Some languages provide
-complicated solutions to this problem, but Janet opts for a much simpler&mdash;if not primitive&mdash;solution.
+is bound to 8) rather than the @code`x` defined to be 10. The problem is the
+reuse of the symbol @code`x` inside the macro, which overshadowed the original
+binding. This problem is called the
+@link[https://en.wikipedia.org/wiki/Hygienic_macro#The_hygiene_problem]{hygiene
+problem} and is well known in many programming languages. Some languages provide
+complicated solutions to this problem, but Janet opts for a much
+simpler&mdash;if not primitive&mdash;solution.
 
-Janet provides a general solution to this problem in terms of the @code[(gensym)] function, which returns
-a symbol which is guaranteed to be unique and not collide with any symbols defined previously. We can define
-our macro once more for a fully correct macro.
+Janet provides a general solution to this problem in terms of the
+@code[(gensym)] function, which returns a symbol which is guaranteed to be
+unique and not collide with any symbols defined previously. We can define our
+macro once more for a fully correct macro.
 
 @codeblock[janet](```janet
 (defmacro max3
@@ -152,8 +161,8 @@ our macro once more for a fully correct macro.
     (if (> ,$x ,$y) ,$x ,$y)))
 ```)
 
-Since it is quite common to create several gensyms for use inside a macro body, Janet
-provides a macro @code[with-syms] to make this definition a bit terser.
+Since it is quite common to create several gensyms for use inside a macro body,
+Janet provides a macro @code[with-syms] to make this definition a bit terser.
 
 @codeblock[janet](```
 (defmacro max4
@@ -165,7 +174,8 @@ provides a macro @code[with-syms] to make this definition a bit terser.
       (if (> ,$x ,$y) ,$x ,$y))))
 ```)
 
-As you can see, macros are very powerful but are also prone to subtle bugs. You must remember that
-at their core, macros are just functions that output code, and the code that they return must
-work in many contexts! Many times a function will suffice and be more useful that a macro, as
-functions can be more easily passed around and used as first class values.
+As you can see, macros are very powerful but are also prone to subtle bugs. You
+must remember that at their core, macros are just functions that output code,
+and the code that they return must work in many contexts! Many times a function
+will suffice and be more useful that a macro, as functions can be more easily
+passed around and used as first class values.

--- a/content/docs/modules.mdz
+++ b/content/docs/modules.mdz
@@ -5,11 +5,11 @@
 
 As programs grow, they should be broken into smaller pieces for
 maintainability. Janet has the concept of modules to this end. A
-module is a collection of bindings and it's associated environment.
-By default, modules correspond one to one with source files in Janet, although
+module is a collection of bindings and its associated environment.
+By default, modules correspond one-to-one with source files in Janet, although
 you may override this and structure modules however you like.
 
-## Installing a Module
+## Installing a module
 
 Using @code`jpm`, the @code`path` module can be installed like so from the command line:
 
@@ -18,18 +18,18 @@ sudo jpm install https://github.com/janet-lang/path.git
 ```
 
 The use of @code`sudo` is not required in some setups, but is often needed
-for a global install on posix systems. You can pass in a git repository URL
-to the install command, and jpm will install that package globally on your system.
+for a global install on POSIX systems. You can pass in a git repository URL
+to the @code`install` command, and @code`jpm` will install that package globally on your system.
 
-If you are not using jpm, you can place the file @code`path.janet` from the repository
-in your current directory, and janet will be able to import it as well. However, for
-more complicated packages or packages containing native C extension, jpm will usually
+If you are not using @code`jpm`, you can place the file @code`path.janet` from the repository
+in your current directory, and Janet will be able to import it as well. However, for
+more complicated packages or packages containing native C extensions, @code`jpm` will usually
 be much easier.
 
-## Importing a Module
+## Importing a module
 
 To use a module, the best way is use the @code`(import)` macro, which
-looks for a module with the given name on your system and imports it's symbols
+looks for a module with the given name on your system and imports its symbols
 into the current environment, usually prefixed with the name of the module.
 
 @codeblock[janet]```
@@ -38,10 +38,10 @@ into the current environment, usually prefixed with the name of the module.
 (path/join (os/cwd) "temp")
 ```
 
-Once @code`path` is imported, all of it's symbols are available to the host program, but
+Once @code`path` is imported, all of its symbols are available to the host program, but
 prefixed with @code`path/`. To import the symbols with a custom prefix or
 without any prefix, use the @code`:prefix` argument
-to the import macro.
+to the @code`import` macro.
 
 @codeblock[janet]```
 (import path :prefix "")
@@ -57,7 +57,7 @@ You may also use the @code`:as` argument to specify the prefix in a more natural
 (p/join (os/cwd) "temp")
 ```
 
-## Custom Loaders (@code`module/paths` and @code`module/loaders`)
+## Custom loaders (@code`module/paths` and @code`module/loaders`)
 
 The @code`module/paths` and @code`module/loaders` data structures determine how Janet
 will load a given module name. @code`module/paths` is a list of patterns and methods
@@ -73,15 +73,15 @@ twice.
 By modifying @code`module/paths` and @code`module/loaders`, you can create
 custom module schemes, handlers for file extensions, or even your own module
 system. It is recommended to not modify existing entries in @code`module/paths`
-or @code`module/loader`, and add on to the existing entries. This is rather
+or @code`module/loader`, and simply add to the existing entries. This is rather
 advanced usage, but can be incredibly useful in creating DSLs that feel
 native to Janet.
 
 ### @code`module/paths`
 
 This is an array of file paths to search for modules in the
-file system. Each element in this array is a tuple @code`[path type predicate]`, where path
-is the a templated file path, which determines what path corresponds to a module name, and
+file system. Each element in this array is a tuple @code`[path type predicate]`, where @code`path`
+is a templated file path, which determines what path corresponds to a module name, and
 where type is the loading method used to load the module. @code`type` can be one of
 @code`:native`, @code`:source`, @code`:image`, or any key in the @code`module/loaders` table.
 
@@ -94,8 +94,8 @@ matches, the function should return a string that will be used as the main ident
 module. Most of the time, this should be the absolute path to the module, but it can be
 any unique key that identifies the module such as an absolute URL. It is this key that is
 used to determine if a module has been loaded already.
-This mechanism lets @code`./mymod` and @code`mymod`
-refer to the same module even though they are different names passed to import.}
+This mechanism lets @code`./mymod` and @code`mymod` refer to the same module even though they are
+different names passed to @code`import`.}
 
 ### @code`module/loaders`
 
@@ -156,7 +156,7 @@ With the above structure, @code`init.janet` can import @code`dep1` and
 @code`mymod/` directory can be installed without any chance that @code`dep1`
 and @code`dep2` will overwrite other files, or that @code`init.janet` will
 accidentally import a different file named @code`dep1.janet` or
-@code`dep2.janet`. @code`mymod` can even be a sub directory in another janet
+@code`dep2.janet`. @code`mymod` can even be a sub-directory in another Janet
 source tree and work as expected.
 
 init.janet
@@ -208,8 +208,8 @@ Sample module:
  (+ 10 (private-fun stuff 1 2)))
 ```
 
-To import our sample module given that it is in some path @code`mymod.janet`, we
-could do something like the following (this also works in a repl):
+To import our sample module given that it stored on disk at @code`mymod.janet`, we
+could do something like the following (this also works in a REPL):
 
 @codeblock[janet]```
 (import mymod)
@@ -224,4 +224,3 @@ mymod/*api-var* # evaluates to 10
 
 (mymod/private-fun 10) # will not compile
 ```
-

--- a/content/docs/modules.mdz
+++ b/content/docs/modules.mdz
@@ -3,34 +3,36 @@
  :order 12}
 ---
 
-As programs grow, they should be broken into smaller pieces for
-maintainability. Janet has the concept of modules to this end. A
-module is a collection of bindings and its associated environment.
-By default, modules correspond one-to-one with source files in Janet, although
-you may override this and structure modules however you like.
+As programs grow, they should be broken into smaller pieces for maintainability.
+Janet has the concept of modules to this end. A module is a collection of
+bindings and its associated environment.  By default, modules correspond
+one-to-one with source files in Janet, although you may override this and
+structure modules however you like.
 
 ## Installing a module
 
-Using @code`jpm`, the @code`path` module can be installed like so from the command line:
+Using @code`jpm`, the @code`path` module can be installed like so from the
+command line:
 
 @codeblock```
 sudo jpm install https://github.com/janet-lang/path.git
 ```
 
-The use of @code`sudo` is not required in some setups, but is often needed
-for a global install on POSIX systems. You can pass in a git repository URL
-to the @code`install` command, and @code`jpm` will install that package globally on your system.
+The use of @code`sudo` is not required in some setups, but is often needed for a
+global install on POSIX systems. You can pass in a git repository URL to the
+@code`install` command, and @code`jpm` will install that package globally on
+your system.
 
-If you are not using @code`jpm`, you can place the file @code`path.janet` from the repository
-in your current directory, and Janet will be able to import it as well. However, for
-more complicated packages or packages containing native C extensions, @code`jpm` will usually
-be much easier.
+If you are not using @code`jpm`, you can place the file @code`path.janet` from
+the repository in your current directory, and Janet will be able to import it as
+well. However, for more complicated packages or packages containing native C
+extensions, @code`jpm` will usually be much easier.
 
 ## Importing a module
 
-To use a module, the best way is use the @code`(import)` macro, which
-looks for a module with the given name on your system and imports its symbols
-into the current environment, usually prefixed with the name of the module.
+To use a module, the best way is use the @code`(import)` macro, which looks for
+a module with the given name on your system and imports its symbols into the
+current environment, usually prefixed with the name of the module.
 
 @codeblock[janet]```
 (import path)
@@ -38,10 +40,10 @@ into the current environment, usually prefixed with the name of the module.
 (path/join (os/cwd) "temp")
 ```
 
-Once @code`path` is imported, all of its symbols are available to the host program, but
-prefixed with @code`path/`. To import the symbols with a custom prefix or
-without any prefix, use the @code`:prefix` argument
-to the @code`import` macro.
+Once @code`path` is imported, all of its symbols are available to the host
+program, but prefixed with @code`path/`. To import the symbols with a custom
+prefix or without any prefix, use the @code`:prefix` argument to the
+@code`import` macro.
 
 @codeblock[janet]```
 (import path :prefix "")
@@ -49,7 +51,8 @@ to the @code`import` macro.
 (join (os/cwd) "temp")
 ```
 
-You may also use the @code`:as` argument to specify the prefix in a more natural way.
+You may also use the @code`:as` argument to specify the prefix in a more natural
+way.
 
 @codeblock[janet]```
 (import path :as p)
@@ -59,64 +62,67 @@ You may also use the @code`:as` argument to specify the prefix in a more natural
 
 ## Custom loaders (@code`module/paths` and @code`module/loaders`)
 
-The @code`module/paths` and @code`module/loaders` data structures determine how Janet
-will load a given module name. @code`module/paths` is a list of patterns and methods
-to use to try and find a given module. The entries in @code`module/paths`
-will be checked in order, as it is possible that multiple entries could match.
-If a module name matches a pattern (which
-usually means that some file exists), then we use the corresponding loader in
+The @code`module/paths` and @code`module/loaders` data structures determine how
+Janet will load a given module name. @code`module/paths` is a list of patterns
+and methods to use to try and find a given module. The entries in
+@code`module/paths` will be checked in order, as it is possible that multiple
+entries could match.  If a module name matches a pattern (which usually means
+that some file exists), then we use the corresponding loader in
 @code`module/loaders` to evaluate that file, source code, URL, or whatever else
-we want to derive from the module name. The resulting value, usually an environment
-table, is then cached so that it can be reused later without evaluating a module
-twice.
+we want to derive from the module name. The resulting value, usually an
+environment table, is then cached so that it can be reused later without
+evaluating a module twice.
 
 By modifying @code`module/paths` and @code`module/loaders`, you can create
 custom module schemes, handlers for file extensions, or even your own module
 system. It is recommended to not modify existing entries in @code`module/paths`
 or @code`module/loader`, and simply add to the existing entries. This is rather
-advanced usage, but can be incredibly useful in creating DSLs that feel
-native to Janet.
+advanced usage, but can be incredibly useful in creating DSLs that feel native
+to Janet.
 
 ### @code`module/paths`
 
-This is an array of file paths to search for modules in the
-file system. Each element in this array is a tuple @code`[path type predicate]`, where @code`path`
-is a templated file path, which determines what path corresponds to a module name, and
-where type is the loading method used to load the module. @code`type` can be one of
-@code`:native`, @code`:source`, @code`:image`, or any key in the @code`module/loaders` table.
+This is an array of file paths to search for modules in the file system. Each
+element in this array is a tuple @code`[path type predicate]`, where @code`path`
+is a templated file path, which determines what path corresponds to a module
+name, and where type is the loading method used to load the module. @code`type`
+can be one of @code`:native`, @code`:source`, @code`:image`, or any key in the
+@code`module/loaders` table.
 
-@p{@code`predicate` is an optional function
-or file extension used to further filter whether or not a module name should match.
-It's mainly useful when @code`path` is a string and you want to further refine the pattern.}
+@p{@code`predicate` is an optional function or file extension used to further
+    filter whether or not a module name should match.  It's mainly useful when
+    @code`path` is a string and you want to further refine the pattern.}
 
-@p{@code`path` can also be a function that checks if a module name matches. If the module name
-matches, the function should return a string that will be used as the main identifier for the
-module. Most of the time, this should be the absolute path to the module, but it can be
-any unique key that identifies the module such as an absolute URL. It is this key that is
-used to determine if a module has been loaded already.
-This mechanism lets @code`./mymod` and @code`mymod` refer to the same module even though they are
-different names passed to @code`import`.}
+@p{@code`path` can also be a function that checks if a module name matches. If
+    the module name matches, the function should return a string that will be
+    used as the main identifier for the module. Most of the time, this should be
+    the absolute path to the module, but it can be any unique key that
+    identifies the module such as an absolute URL. It is this key that is used
+    to determine if a module has been loaded already.  This mechanism lets
+    @code`./mymod` and @code`mymod` refer to the same module even though they
+    are different names passed to @code`import`.}
 
 ### @code`module/loaders`
 
 Once a primary module identifier and module type has been chosen, Janet's import
-machinery (defined mostly in @code`require` and @code`module/find`) will use
-the appropriate loader from @code`module/loaders` to get an environment table.
-Each loader in the table is just a function that takes the primary module identifier
-(usually an absolute path to the module) as well as optionally any other arguments
-passed to @code`require` or @code`import`, and returns the environment table.
-For example, the @code`:source` type is a thin wrapper around @code`dofile`, the
-@code`:image` type is a wrapper around @code`load-image`, and the @code`:native` type
-is a wrapper around @code`native`.
+machinery (defined mostly in @code`require` and @code`module/find`) will use the
+appropriate loader from @code`module/loaders` to get an environment table.  Each
+loader in the table is just a function that takes the primary module identifier
+(usually an absolute path to the module) as well as optionally any other
+arguments passed to @code`require` or @code`import`, and returns the environment
+table.  For example, the @code`:source` type is a thin wrapper around
+@code`dofile`, the @code`:image` type is a wrapper around @code`load-image`, and
+the @code`:native` type is a wrapper around @code`native`.
 
 ### URL loader example
 
-An example from @code`examples/urlloader.janet` in the source repository shows how
-a loader can be a wrapper around curl and @code`dofile` to load source files from HTTP URLs.
-To use it, simply evaluate this file somewhere in your program before you require code from
-a URL. Don't use this as is in production code, as if @code`url` contains spaces in @code`load-url`
-the module will not load correctly. A more robust solution would quote the URL, or better yet
-use @code`os/execute` and write to a temporary file instead of @code`file/popen`.
+An example from @code`examples/urlloader.janet` in the source repository shows
+how a loader can be a wrapper around curl and @code`dofile` to load source files
+from HTTP URLs.  To use it, simply evaluate this file somewhere in your program
+before you require code from a URL. Don't use this as is in production code, as
+if @code`url` contains spaces in @code`load-url` the module will not load
+correctly. A more robust solution would quote the URL, or better yet use
+@code`os/execute` and write to a temporary file instead of @code`file/popen`.
 
 @codeblock[janet]```
 (defn- load-url
@@ -139,9 +145,9 @@ use @code`os/execute` and write to a temporary file instead of @code`file/popen`
 
 ## Relative imports
 
-You can include files relative to the current file by prefixing
-the module name with a @code`./`. For example, if you have a file tree
-that is structured like so:
+You can include files relative to the current file by prefixing the module name
+with a @code`./`. For example, if you have a file tree that is structured like
+so:
 
 @codeblock```
 mymod/
@@ -153,8 +159,8 @@ mymod/
 
 With the above structure, @code`init.janet` can import @code`dep1` and
 @code`dep2` with relative imports. This is less brittle as the entire
-@code`mymod/` directory can be installed without any chance that @code`dep1`
-and @code`dep2` will overwrite other files, or that @code`init.janet` will
+@code`mymod/` directory can be installed without any chance that @code`dep1` and
+@code`dep2` will overwrite other files, or that @code`init.janet` will
 accidentally import a different file named @code`dep1.janet` or
 @code`dep2.janet`. @code`mymod` can even be a sub-directory in another Janet
 source tree and work as expected.
@@ -170,11 +176,12 @@ init.janet
 ## Writing a module
 
 Writing a module in Janet is mostly about exposing only the public functions
-that you want users of your module to be able to use. All top level functions defined
-via @code`defn`, macros defined @code`defmacro`, constants defined via @code`def`, and
-vars defined via @code`var` will be exported in your module. To mark a function or
-binding as private to your module, you may use @code`defn-` or @code`def-` at the top level.
-You can also add the @code`:private` metadata to the binding.
+that you want users of your module to be able to use. All top level functions
+defined via @code`defn`, macros defined @code`defmacro`, constants defined via
+@code`def`, and vars defined via @code`var` will be exported in your module. To
+mark a function or binding as private to your module, you may use @code`defn-`
+or @code`def-` at the top level.  You can also add the @code`:private` metadata
+to the binding.
 
 Sample module:
 
@@ -208,8 +215,8 @@ Sample module:
  (+ 10 (private-fun stuff 1 2)))
 ```
 
-To import our sample module given that it stored on disk at @code`mymod.janet`, we
-could do something like the following (this also works in a REPL):
+To import our sample module given that it stored on disk at @code`mymod.janet`,
+we could do something like the following (this also works in a REPL):
 
 @codeblock[janet]```
 (import mymod)

--- a/content/docs/numbers.mdz
+++ b/content/docs/numbers.mdz
@@ -4,7 +4,7 @@
 ---
 
 Any programming language will have some way to do arithmetic. Janet is no exception,
-and supports the basic arithmetic operators
+and supports the basic arithmetic operators.
 
 @codeblock[janet](```
 # Prints 13
@@ -12,12 +12,12 @@ and supports the basic arithmetic operators
 (print (+ 1 (* 2 2) (/ 10 5) 3 4 (- 5 6)))
 ```)
 
-Just like the print function, all arithmetic operators are entered in
+Just like the @code`print` function, all arithmetic operators are entered in
 prefix notation. Janet also supports the remainder operator, or @code[%], which returns
 the remainder of division. For example, @code[(% 10 3)] is 1, and @code[(% 10.5 3)] is
 1.5. The lines that begin with @code[#] are comments.
 
-All janet numbers are IEEE 754 double precision floating point numbers. They can be used to represent
+All Janet numbers are IEEE 754 double precision floating point numbers. They can be used to represent
 both integers and real numbers to a finite precision.
 
 ## Numeric literals
@@ -29,9 +29,9 @@ base and the character 'r'. For example, 16 can be written as @code[16], @code[1
 @code[0x] prefix can be used for hexadecimal as it is so common. The radix must be themselves written in base 10, and
 can be any integer from 2 to 36. For any radix above 10, use the letters as digits (not case sensitive).
 
-Numbers can also be in scientific notation such as @code[3e10]. A custom radix can be used as well
-as for scientific notation numbers, (the exponent will share the radix). For numbers in scientific
-notation with a radix besides 10, use the @code[&] symbol to indicate the exponent rather then @code[e].
+Numbers can also be in scientific notation such as @code[3e10]. A custom radix can be used
+for scientific notation numbers (the exponent will share the radix). For numbers in scientific
+notation with a radix other than 10, use the @code[&] symbol to indicate the exponent rather than @code[e].
 
 Some example numbers:
 @codeblock[janet]```
@@ -48,17 +48,16 @@ Some example numbers:
 
 Janet will allow some pretty wacky formats for numbers. However, no matter what format
 you write your number in, the resulting value will always be a double precision
-floating point number. 
+floating point number.
 
-## Arithmetic Functions
+## Arithmetic functions
 
-Besides the 5 main arithmetic functions, janet also supports a number of math functions
+Besides the 5 main arithmetic functions, Janet also supports a number of math functions
 taken from the C library @code[<math.h>], as well as bit-wise operators that behave like they
 do in C or Java. Functions like @code[math/sin], @code[math/cos], @code[math/log], and @code[math/exp] will
 behave as expected to a C programmer. They all take either 1 or 2 numeric arguments and
-return a real number (never an integer!) Bit-wise functions are all prefixed with b.
+return a real number (never an integer!). Bit-wise functions are all prefixed with @code`b`.
 They are @code[bnot], @code[bor], @code[bxor], @code[band], @code[blshift], @code[brshift], and @code[brushift]. Bit-wise
 functions only work on integers.
 
-See the @link[doc.html#math/acos][Core Library API] for info on functions in the @code[math/] namespace.
-
+See the @link[/api/math.html][Math API] for information on functions in the @code[math/] namespace.

--- a/content/docs/numbers.mdz
+++ b/content/docs/numbers.mdz
@@ -3,8 +3,8 @@
  :order 3}
 ---
 
-Any programming language will have some way to do arithmetic. Janet is no exception,
-and supports the basic arithmetic operators.
+Any programming language will have some way to do arithmetic. Janet is no
+exception, and supports the basic arithmetic operators.
 
 @codeblock[janet](```
 # Prints 13
@@ -13,25 +13,29 @@ and supports the basic arithmetic operators.
 ```)
 
 Just like the @code`print` function, all arithmetic operators are entered in
-prefix notation. Janet also supports the remainder operator, or @code[%], which returns
-the remainder of division. For example, @code[(% 10 3)] is 1, and @code[(% 10.5 3)] is
-1.5. The lines that begin with @code[#] are comments.
+prefix notation. Janet also supports the remainder operator, or @code[%], which
+returns the remainder of division. For example, @code[(% 10 3)] is 1, and
+@code[(% 10.5 3)] is 1.5. The lines that begin with @code[#] are comments.
 
-All Janet numbers are IEEE 754 double precision floating point numbers. They can be used to represent
-both integers and real numbers to a finite precision.
+All Janet numbers are IEEE 754 double precision floating point numbers. They can
+be used to represent both integers and real numbers to a finite precision.
 
 ## Numeric literals
 
-Numeric literals can be written in many ways. Numbers can be written in base 10, with
-underscores used to separate digits into groups. A decimal point can be used for floating
-point numbers. Numbers can also be written in other bases by prefixing the number with the desired
-base and the character 'r'. For example, 16 can be written as @code[16], @code[1_6], @code[16r10], @code[4r100], or @code[0x10]. The
-@code[0x] prefix can be used for hexadecimal as it is so common. The radix must be themselves written in base 10, and
-can be any integer from 2 to 36. For any radix above 10, use the letters as digits (not case sensitive).
+Numeric literals can be written in many ways. Numbers can be written in base 10,
+with underscores used to separate digits into groups. A decimal point can be
+used for floating point numbers. Numbers can also be written in other bases by
+prefixing the number with the desired base and the character 'r'. For example,
+16 can be written as @code[16], @code[1_6], @code[16r10], @code[4r100], or
+@code[0x10]. The @code[0x] prefix can be used for hexadecimal as it is so
+common. The radix must be themselves written in base 10, and can be any integer
+from 2 to 36. For any radix above 10, use the letters as digits (not case
+sensitive).
 
-Numbers can also be in scientific notation such as @code[3e10]. A custom radix can be used
-for scientific notation numbers (the exponent will share the radix). For numbers in scientific
-notation with a radix other than 10, use the @code[&] symbol to indicate the exponent rather than @code[e].
+Numbers can also be in scientific notation such as @code[3e10]. A custom radix
+can be used for scientific notation numbers (the exponent will share the radix).
+For numbers in scientific notation with a radix other than 10, use the @code[&]
+symbol to indicate the exponent rather than @code[e].
 
 Some example numbers:
 @codeblock[janet]```
@@ -46,18 +50,20 @@ Some example numbers:
 # evaluates to 1.72625e+13 in base 10
 ```
 
-Janet will allow some pretty wacky formats for numbers. However, no matter what format
-you write your number in, the resulting value will always be a double precision
-floating point number.
+Janet will allow some pretty wacky formats for numbers. However, no matter what
+format you write your number in, the resulting value will always be a double
+precision floating point number.
 
 ## Arithmetic functions
 
-Besides the 5 main arithmetic functions, Janet also supports a number of math functions
-taken from the C library @code[<math.h>], as well as bit-wise operators that behave like they
-do in C or Java. Functions like @code[math/sin], @code[math/cos], @code[math/log], and @code[math/exp] will
-behave as expected to a C programmer. They all take either 1 or 2 numeric arguments and
-return a real number (never an integer!). Bit-wise functions are all prefixed with @code`b`.
-They are @code[bnot], @code[bor], @code[bxor], @code[band], @code[blshift], @code[brshift], and @code[brushift]. Bit-wise
-functions only work on integers.
+Besides the 5 main arithmetic functions, Janet also supports a number of math
+functions taken from the C library @code[<math.h>], as well as bit-wise
+operators that behave like they do in C or Java. Functions like @code[math/sin],
+@code[math/cos], @code[math/log], and @code[math/exp] will behave as expected to
+a C programmer. They all take either 1 or 2 numeric arguments and return a real
+number (never an integer!). Bit-wise functions are all prefixed with @code`b`.
+They are @code[bnot], @code[bor], @code[bxor], @code[band], @code[blshift],
+@code[brshift], and @code[brushift]. Bit-wise functions only work on integers.
 
-See the @link[/api/math.html][Math API] for information on functions in the @code[math/] namespace.
+See the @link[/api/math.html][Math API] for information on functions in the
+@code[math/] namespace.

--- a/content/docs/object_oriented.mdz
+++ b/content/docs/object_oriented.mdz
@@ -4,17 +4,17 @@
 ---
 
 Although Janet is primarily a functional language, it has support for
-object-oriented programming as well, where objects and classes are
-represented by tables. Object-oriented programming can be very useful
-in domains that are less analytical and more about modeling, such as
-some simulations, GUIs, and game scripting. More specifically, Janet supports
-a form of object-oriented programming via prototypical inheritance, which was pioneered in the
-@link[http://www.selflanguage.org/][Self] language and is used in languages like Lua
-and JavaScript. Janet's implementation of object-oriented programming is
+object-oriented programming as well, where objects and classes are represented
+by tables. Object-oriented programming can be very useful in domains that are
+less analytical and more about modeling, such as some simulations, GUIs, and
+game scripting. More specifically, Janet supports a form of object-oriented
+programming via prototypical inheritance, which was pioneered in the
+@link[http://www.selflanguage.org/][Self] language and is used in languages like
+Lua and JavaScript. Janet's implementation of object-oriented programming is
 designed to be simple, terse, flexible, and efficient in that order of priority.
 
-Please see the @link[/docs/prototypes.html][prototypes section] for more information
-on table prototypes.
+Please see the @link[/docs/prototypes.html][prototypes section] for more
+information on table prototypes.
 
 For example:
 
@@ -46,8 +46,8 @@ when it is not used in the function body.
 
 ## Factory functions
 
-Rather than constructors, creating objects in Janet can usually be done with
-a factory function. One can wrap the boilerplate of initializing fields and
+Rather than constructors, creating objects in Janet can usually be done with a
+factory function. One can wrap the boilerplate of initializing fields and
 setting the table prototype using a single function to create a nice interface.
 
 @codeblock[janet]```
@@ -64,15 +64,16 @@ setting the table prototype using a single function to create a nice interface.
 (c3 :serial-number) # 0.783099
 ```
 
-One could also define a set of macros for creating objects with useful factory functions, methods, and
-properties. The core library does not currently provide such functionality, as it should be fairly simple
-to customize.
+One could also define a set of macros for creating objects with useful factory
+functions, methods, and properties. The core library does not currently provide
+such functionality, as it should be fairly simple to customize.
 
 ## Structs
 
-In addition to tables, Structs may also be used as objects. Structs are of limited use, however, because
-they do not have prototypes. This means that they cannot implement any form of inheritance. The above example
-would work for the first object @code`Car`, but @code`RedCar` could not inherit from @code`Car`.
+In addition to tables, Structs may also be used as objects. Structs are of
+limited use, however, because they do not have prototypes. This means that they
+cannot implement any form of inheritance. The above example would work for the
+first object @code`Car`, but @code`RedCar` could not inherit from @code`Car`.
 
 @codeblock[janet]```
 # Create a new struct object called Car with two methods, :say and :honk.
@@ -90,10 +91,11 @@ would work for the first object @code`Car`, but @code`RedCar` could not inherit 
 
 ## Abstract types
 
-While tables make good objects, Janet also strives for good interoperation with C.
-Many C libraries expose pseudo object-oriented interfaces to their libraries, so
-Janet allows methods to be added to abstract types. The built in abstract type
-@code`:core/file` can be manipulated with methods as well as the @code`file/` functions.
+While tables make good objects, Janet also strives for good interoperation with
+C.  Many C libraries expose pseudo object-oriented interfaces to their
+libraries, so Janet allows methods to be added to abstract types. The built in
+abstract type @code`:core/file` can be manipulated with methods as well as the
+@code`file/` functions.
 
 @codeblock[janet]```
 (file/read stdin :line)

--- a/content/docs/object_oriented.mdz
+++ b/content/docs/object_oriented.mdz
@@ -1,16 +1,16 @@
-{:title "Object Oriented Programming"
+{:title "Object-Oriented Programming"
  :template "docpage.html"
  :order 14}
 ---
 
 Although Janet is primarily a functional language, it has support for
-Object Oriented programming as well, where objects and classes are
-represented by tables. Object oriented programming can be very useful
+object-oriented programming as well, where objects and classes are
+represented by tables. Object-oriented programming can be very useful
 in domains that are less analytical and more about modeling, such as
 some simulations, GUIs, and game scripting. More specifically, Janet supports
-a form of Object Oriented programming via prototypical inheritance, which was pioneered in the
+a form of object-oriented programming via prototypical inheritance, which was pioneered in the
 @link[http://www.selflanguage.org/][Self] language and is used in languages like Lua
-and JavaScript. Janet's implementation of Object Oriented programming is
+and JavaScript. Janet's implementation of object-oriented programming is
 designed to be simple, terse, flexible, and efficient in that order of priority.
 
 Please see the @link[/docs/prototypes.html][prototypes section] for more information
@@ -88,11 +88,11 @@ would work for the first object @code`Car`, but @code`RedCar` could not inherit 
 (:say Car "hello!") # prints "Car says: hello!"
 ```
 
-## Abstract Types
+## Abstract types
 
 While tables make good objects, Janet also strives for good interoperation with C.
-Many C libraries expose pseudo Object Oriented interfaces to their libraries, so
-Janet allows adding methods to abstract types. The built in abstract type
+Many C libraries expose pseudo object-oriented interfaces to their libraries, so
+Janet allows methods to be added to abstract types. The built in abstract type
 @code`:core/file` can be manipulated with methods as well as the @code`file/` functions.
 
 @codeblock[janet]```

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -12,17 +12,18 @@ be very complex to maintain and may not exist for many languages. String functio
 powerful enough for a large class of languages, and regular expressions can be hard to read
 (which characters are escaped?) and under-powered (don't parse HTML with regex!).
 
-PEGs, or Parsing Expression Grammars, are another formalism for recognizing languages that
+PEGs, or Parsing Expression Grammars, are another formalism for recognizing languages. PEGs
 are easier to write than a custom parser and more powerful than regular expressions. They also
 can produce grammars that are easily understandable and fast. PEGs can also be compiled
 to a bytecode format that can be reused. Janet offers the @code`peg` module for writing and
 evaluating PEGs.
 
 Janet's @code`peg` module borrows syntax and ideas from both LPeg and REBOL/Red parse module. Janet has
-no built in regex module because PEGs offer a superset of regex's functionality.
+no built-in regex module because PEGs offer a superset of the functionality of
+regular expressions.
 
 Below is a simple example for checking if a string is a valid IP address. Notice how
-the grammar is descriptive enough that you can read it even if you don't know the peg
+the grammar is descriptive enough that you can read it even if you don't know the PEG
 syntax (example is translated from a @link[https://www.red-lang.org/2013/11/041-introducing-parse.html][RED language blog post]).
 
 @codeblock[janet]```
@@ -53,25 +54,25 @@ many times.
 
 ### @code`(peg/match peg text [,start=0] & arguments)`
 
-Match a peg against some text. Returns an array of captured data if the text
-matches, or nil if there is no match. The caller can provide an optional start
-index to begin matching the text at, otherwise the PEG starts on the first character
-of text. A peg can either a compile PEG object or peg source.
+Match a PEG against some text. Returns an array of captured data if the text
+matches, or @code`nil` if there is no match. The caller can provide an optional @code`start`
+index to begin matching, otherwise the PEG starts on the first character
+of text. A PEG can either bea compiled PEG object or PEG source.
 
 ### @code`(peg/compile peg)`
 
-Compiles a peg source data structure into a new PEG. Throws an error if there are problems
-with the peg code.
+Compiles a PEG source data structure into a new PEG. Throws an error if there are problems
+with the PEG code.
 
-## Primitive Patterns
+## Primitive patterns
 
 Larger patterns are built up with primitive patterns, which recognize individual
 characters, string literals, or a given number of characters. A character in Janet
 is considered a byte, so PEGs will work on any string of bytes. No special meaning is
-given to the 0 byte, or the string terminator in many languages.
+given to the @code`0` byte, or the string terminator as in many languages.
 
 @tag[table]{
-    @tr{@th{Pattern Signature} @th{What it Matches}}
+    @tr{@th{Pattern Signature} @th{What it matches}}
     @tr{@td{string ("cat")   } @td{ The literal string. }}
     @tr{@td{integer (3)      } @td{ Matches a number of characters, and advances that many characters. If negative, matches if not that many characters and does not advance. For example, -1 will match the end of a string }}
     @tr{@td{@code`(range "az" "AZ")` } @td{ Matches characters in a range and advances 1 character. Multiple ranges can be combined together. }}
@@ -91,7 +92,7 @@ Primitive patterns are not that useful by themselves, but can be passed to @code
 (peg/match '(set "ABCDEFGHIJKLMNOPQRSTUVWXYZ") "F") # -> @[]
 ```
 
-## Combining Patterns
+## Combining patterns
 
 These primitive patterns can be combined with several combinators to match a wide number of
 languages. These combinators
@@ -120,21 +121,21 @@ can be thought of as the looping and branching forms in a traditional language
 
 PEGs try to match an input text with a pattern in a greedy manner.
 This means that if a rule fails to match, that rule will fail and not try again. The only
-backtracking provided in a peg is provided by the @code`(choice x y z ...)` special, which will
-try rules in order until one succeeds, and the whole pattern succeeds. If no sub pattern
+backtracking provided in a PEG is provided by the @code`(choice x y z ...)` special, which will
+try rules in order until one succeeds, and the whole pattern succeeds. If no sub-pattern
 succeeds, then the whole pattern fails. Note that this means that the order of @code`x y z` in choice
-DOES matter. If y matches everything that z matches, z will never succeed.
+@strong{does} matter. If @code`y` matches everything that @code`z` matches, @code`z` will never succeed.
 
 ## Captures
 
 So far we have only been concerned with "does this text match this language?". This is useful, but
-it is often more useful to extract data from text if it does match a peg. The @code`peg` module
+it is often more useful to extract data from text if it does match a PEG. The @code`peg` module
 uses that concept of a capture stack to extract data from text. As the PEG is trying to match
 a piece of text, some forms may push Janet values onto the capture stack as a side effect. If the
-text matches the main peg language, @code`(peg/match)` will return the final capture stack as an array.
+text matches the main PEG language, @code`(peg/match)` will return the final capture stack as an array.
 
 Capture specials will only push captures to the capture stack if their child pattern matches the text.
-Most captures specials will match the same text as their first argument pattern. Also most specials
+Most captures specials will match the same text as their first argument pattern. In addition, most specials
 that produce captures can take an optional argument @code`tag` that applies a keyword tag to the capture.
 These tagged captures can then be recaptured via the @code`(backref tag)` special in subsequent matches.
 Tagged captures, when combined with the @code`(cmt)` special, provide a powerful form of look-behind
@@ -161,13 +162,13 @@ that can make many grammars simpler.
     @tr{@td{@code`(drop patt)` } @td{ Ignores (drops) all captures from patt. }}
     @tr{@td{@code`(lenprefix n patt)` } @td{ Matches n repetitions of a pattern, where n is supplied from other parsed input and is not a constant. }}}
 
-## Grammars and Recursion
+## Grammars and recursion
 
 The feature that makes PEGs so much more powerful than pattern matching solutions like (vanilla) regex is mutual recursion.
-To do recursion in a peg, you can wrap multiple patterns in a grammar, which is a Janet struct. The patterns must be named by
+To do recursion in a PEG, you can wrap multiple patterns in a grammar, which is a Janet struct. The patterns must be named by
 keywords, which can then be used in all sub-patterns in the grammar.
 
-Each grammar, defined by a struct, must also have a main rule, called :main, that is the pattern that the entire grammar
+Each grammar, defined by a struct, must also have a main rule, called @code`:main`, that is the pattern that the entire grammar
 is defined by.
 
 An example grammar that uses mutual recursion:
@@ -185,16 +186,17 @@ An example grammar that uses mutual recursion:
 ```
 
 Keep in mind that recursion is implemented with a stack, meaning that very recursive grammars
-can overflow the stack. The compiler is able to turn some recursion into iteration via tail call optimization, but some patterns
+can overflow the stack. The compiler is able to turn some recursion into iteration via tail-call optimization, but some patterns
 may fail on large inputs. It is also possible to construct (very poorly written) patterns that will result in long loops and be very
 slow in general.
 
-## Built-in Patterns
+## Built-in patterns
 
 Besides the primitive patterns and pattern combinators given above, the @code`peg` module also
 provides a default grammar with a handful of commonly used patterns. All of these shorthands
-can be defined with the combinators above and primitive patterns, but these aliases may come up
-a lot when writing grammars.
+can be defined with the combinators above and primitive patterns, but you may
+see these aliases in other grammars and they can make grammar simpler and easier
+to read.
 
 @tag[table]{
     @tr{@th{Name} @th{Expanded} @th{Description}}
@@ -221,12 +223,13 @@ a lot when writing grammars.
 
 All of these aliases are defined in @code`default-peg-grammar`, which is a table that maps
 from the alias name to the expanded form. You can even add your own aliases here which are then
-available for all pegs in the program. Modifiying this table will not affect already compiled pegs.
+available for all PEGs in the program. Modifiying this table will not affect
+already compiled PEGs.
 
-## String Searching and other Idioms
+## String searching and other idioms
 
 Although all pattern matching is done in anchored mode, operations like global substitution
-and searching can be implemented with the peg module. A simple Janet function that produces PEGs
+and searching can be implemented with the PEG module. A simple Janet function that produces PEGs
 that search for strings shows how captures and looping specials can composed, and how quasiquoting
 can be used to embed values in patterns.
 
@@ -247,7 +250,7 @@ can be used to embed values in patterns.
 (peg/match find-cats "cat ct caat caaaaat cat") # -> @[0 7 12 20]
 ```
 
-We can also wrap a peg to turn it into a global substitution grammar with
+We can also wrap a PEG to turn it into a global substitution grammar with
 the accumulate special @code`(%)`.
 
 @codeblock[janet]```

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -3,28 +3,30 @@
  :order 15}
 ---
 
-A common programming task is recognizing patterns in text, be it
-filtering emails from a list or extracting data from a CSV file. Programming
-languages and libraries usually offer a number of tools for this, including prebuilt
-parsers, simple operations on strings (splitting a string on commas), and regular expressions.
-The pre-built or custom-built parser is usually the most robust solution, but can
-be very complex to maintain and may not exist for many languages. String functions are not
-powerful enough for a large class of languages, and regular expressions can be hard to read
-(which characters are escaped?) and under-powered (don't parse HTML with regex!).
+A common programming task is recognizing patterns in text, be it filtering
+emails from a list or extracting data from a CSV file. Programming languages and
+libraries usually offer a number of tools for this, including prebuilt parsers,
+simple operations on strings (splitting a string on commas), and regular
+expressions.  The pre-built or custom-built parser is usually the most robust
+solution, but can be very complex to maintain and may not exist for many
+languages. String functions are not powerful enough for a large class of
+languages, and regular expressions can be hard to read (which characters are
+escaped?) and under-powered (don't parse HTML with regex!).
 
-PEGs, or Parsing Expression Grammars, are another formalism for recognizing languages. PEGs
-are easier to write than a custom parser and more powerful than regular expressions. They also
-can produce grammars that are easily understandable and fast. PEGs can also be compiled
-to a bytecode format that can be reused. Janet offers the @code`peg` module for writing and
-evaluating PEGs.
+PEGs, or Parsing Expression Grammars, are another formalism for recognizing
+languages. PEGs are easier to write than a custom parser and more powerful than
+regular expressions. They also can produce grammars that are easily
+understandable and fast. PEGs can also be compiled to a bytecode format that can
+be reused. Janet offers the @code`peg` module for writing and evaluating PEGs.
 
-Janet's @code`peg` module borrows syntax and ideas from both LPeg and REBOL/Red parse module. Janet has
-no built-in regex module because PEGs offer a superset of the functionality of
-regular expressions.
+Janet's @code`peg` module borrows syntax and ideas from both LPeg and REBOL/Red
+parse module. Janet has no built-in regex module because PEGs offer a superset
+of the functionality of regular expressions.
 
-Below is a simple example for checking if a string is a valid IP address. Notice how
-the grammar is descriptive enough that you can read it even if you don't know the PEG
-syntax (example is translated from a @link[https://www.red-lang.org/2013/11/041-introducing-parse.html][RED language blog post]).
+Below is a simple example for checking if a string is a valid IP address. Notice
+how the grammar is descriptive enough that you can read it even if you don't
+know the PEG syntax (example is translated from a
+@link[https://www.red-lang.org/2013/11/041-introducing-parse.html][RED language blog post]).
 
 @codeblock[janet]```
 (def ip-address
@@ -46,40 +48,55 @@ syntax (example is translated from a @link[https://www.red-lang.org/2013/11/041-
 
 ## The API
 
-The @code`peg` module has few functions because the complexity is exposed through the
-pattern syntax. Note that there is only one match function, @code`peg/match`. Variations
-on matching, such as parsing or searching, can be implemented inside patterns.
-PEGs can also be compiled ahead of time with @code`peg/compile` if a PEG will be reused
-many times.
+The @code`peg` module has few functions because the complexity is exposed
+through the pattern syntax. Note that there is only one match function,
+@code`peg/match`. Variations on matching, such as parsing or searching, can be
+implemented inside patterns.  PEGs can also be compiled ahead of time with
+@code`peg/compile` if a PEG will be reused many times.
 
 ### @code`(peg/match peg text [,start=0] & arguments)`
 
 Match a PEG against some text. Returns an array of captured data if the text
-matches, or @code`nil` if there is no match. The caller can provide an optional @code`start`
-index to begin matching, otherwise the PEG starts on the first character
-of text. A PEG can either bea compiled PEG object or PEG source.
+matches, or @code`nil` if there is no match. The caller can provide an optional
+@code`start` index to begin matching, otherwise the PEG starts on the first
+character of text. A PEG can either bea compiled PEG object or PEG source.
 
 ### @code`(peg/compile peg)`
 
-Compiles a PEG source data structure into a new PEG. Throws an error if there are problems
-with the PEG code.
+Compiles a PEG source data structure into a new PEG. Throws an error if there
+are problems with the PEG code.
 
 ## Primitive patterns
 
 Larger patterns are built up with primitive patterns, which recognize individual
-characters, string literals, or a given number of characters. A character in Janet
-is considered a byte, so PEGs will work on any string of bytes. No special meaning is
-given to the @code`0` byte, or the string terminator as in many languages.
+characters, string literals, or a given number of characters. A character in
+Janet is considered a byte, so PEGs will work on any string of bytes. No special
+meaning is given to the @code`0` byte, or the string terminator as in many
+languages.
 
 @tag[table]{
-    @tr{@th{Pattern Signature} @th{What it matches}}
-    @tr{@td{string ("cat")   } @td{ The literal string. }}
-    @tr{@td{integer (3)      } @td{ Matches a number of characters, and advances that many characters. If negative, matches if not that many characters and does not advance. For example, -1 will match the end of a string }}
-    @tr{@td{@code`(range "az" "AZ")` } @td{ Matches characters in a range and advances 1 character. Multiple ranges can be combined together. }}
-    @tr{@td{@code`(set "abcd")`  } @td{ Match any character in the argument string. Advances 1 character. }}
+    @tr{@th{Pattern Signature}
+        @th{What it matches}}
+
+    @tr{@td{string ("cat")}
+        @td{ The literal string. }}
+
+    @tr{@td{integer (3)}
+        @td{ Matches a number of characters, and advances that many characters.
+        If negative, matches if not that many characters and does not advance.
+        For example, -1 will match the end of a string }}
+
+    @tr{@td{@code`(range "az" "AZ")` }
+        @td{ Matches characters in a range and advances 1 character. Multiple
+        ranges can be combined together. }}
+
+    @tr{@td{@code`(set "abcd")`}
+        @td{ Match any character in the argument string. Advances 1 character.
+        }}
 }
 
-Primitive patterns are not that useful by themselves, but can be passed to @code`peg/match` and @code`peg/compile` like any other pattern.
+Primitive patterns are not that useful by themselves, but can be passed to
+@code`peg/match` and @code`peg/compile` like any other pattern.
 
 @codeblock[janet]```
 (peg/match "hello" "hello") # -> @[]
@@ -94,82 +111,185 @@ Primitive patterns are not that useful by themselves, but can be passed to @code
 
 ## Combining patterns
 
-These primitive patterns can be combined with several combinators to match a wide number of
-languages. These combinators
-can be thought of as the looping and branching forms in a traditional language
-(that is how they are implemented when compiled to bytecode).
+These primitive patterns can be combined with several combinators to match a
+wide number of languages. These combinators can be thought of as the looping and
+branching forms in a traditional language (that is how they are implemented when
+compiled to bytecode).
 
 @tag[table]{
-    @tr{@th{Pattern Signature} @th{What it matches}}
-    @tr{@td{@code`(choice a b c ...)` } @td{ Tries to match a, then b, and so on. Will succeed on the first successful match, and fails if none of the arguments match the text. }}
-    @tr{@td{@code`(+ a b c ...)` } @td{ Alias for @code`(choice a b c ...)` }}
-    @tr{@td{@code`(sequence a b c)` } @td{ Tries to match a, b, c and so on in sequence. If any of these arguments fail to match the text, the whole pattern fails. }}
-    @tr{@td{@code`(* a b c ...)` } @td{ Alias for @code`(sequence a b c ...)` }}
-    @tr{@td{@code`(any x)` } @td{ Matches 0 or more repetitions of x. }}
-    @tr{@td{@code`(some x)` } @td{ Matches 1 or more repetitions of x. }}
-    @tr{@td{@code`(between min max x)` } @td{ Matches between min and max (inclusive) repetitions of x. }}
-    @tr{@td{@code`(at-least n x)` } @td{ Matches at least n repetitions of x. }}
-    @tr{@td{@code`(at-most n x)` } @td{  Matches at most n repetitions of x. }}
-    @tr{@td{@code`(if cond patt)` } @td{ Tries to match patt only if cond matches as well. cond will not produce any captures. }}
-    @tr{@td{@code`(if-not cond patt)` } @td{ Tries to match only if cond does not match. cond will not produce any captures. }}
-    @tr{@td{@code`(not patt)` } @td{ Matches only if patt does not match. Will not produce captures or advance any characters. }}
-    @tr{@td{@code`(! patt)`   } @td{ Alias for @code`(not patt)` }}
-    @tr{@td{@code`(look offset patt)` } @td{ Matches only if patt matches at a fixed offset. offset can be any integer. patt will not produce captures and the peg will not advance any characters. }}
-    @tr{@td{@code`(> offset patt)` } @td{ Alias for @code`(look offset patt)` }}
-    @tr{@td{@code`(opt patt)` } @td{ Alias for @code`(between 0 1 patt)` }}
-    @tr{@td{@code`(? patt)` } @td{ Alias for @code`(between 0 1 patt)` }}}
+    @tr{@th{Pattern Signature}
+        @th{What it matches}}
 
-PEGs try to match an input text with a pattern in a greedy manner.
-This means that if a rule fails to match, that rule will fail and not try again. The only
-backtracking provided in a PEG is provided by the @code`(choice x y z ...)` special, which will
-try rules in order until one succeeds, and the whole pattern succeeds. If no sub-pattern
-succeeds, then the whole pattern fails. Note that this means that the order of @code`x y z` in choice
-@strong{does} matter. If @code`y` matches everything that @code`z` matches, @code`z` will never succeed.
+    @tr{@td{@code`(choice a b c ...)` }
+        @td{ Tries to match a, then b, and so on. Will succeed on the first
+        successful match, and fails if none of the arguments match the text. }}
+
+    @tr{@td{@code`(+ a b c ...)` }
+        @td{ Alias for @code`(choice a b c ...)` }}
+
+    @tr{@td{@code`(sequence a b c)` }
+        @td{ Tries to match a, b, c and so on in sequence. If any of these
+        arguments fail to match the text, the whole pattern fails. }}
+
+    @tr{@td{@code`(* a b c ...)` }
+        @td{ Alias for @code`(sequence a b c ...)` }}
+
+    @tr{@td{@code`(any x)` }
+        @td{ Matches 0 or more repetitions of x. }}
+
+    @tr{@td{@code`(some x)` }
+        @td{ Matches 1 or more repetitions of x. }}
+
+    @tr{@td{@code`(between min max x)` }
+        @td{ Matches between min and max (inclusive) repetitions of x. }}
+
+    @tr{@td{@code`(at-least n x)` }
+        @td{ Matches at least n repetitions of x. }}
+
+    @tr{@td{@code`(at-most n x)` }
+        @td{  Matches at most n repetitions of x. }}
+
+    @tr{@td{@code`(if cond patt)` }
+        @td{ Tries to match patt only if cond matches as well. cond will not
+        produce any captures. }}
+
+    @tr{@td{@code`(if-not cond patt)` }
+        @td{ Tries to match only if cond does not match. cond will not produce
+        any captures. }}
+
+    @tr{@td{@code`(not patt)` }
+        @td{ Matches only if patt does not match. Will not produce captures or
+        advance any characters. }}
+
+    @tr{@td{@code`(! patt)`   }
+    @td{ Alias for @code`(not patt)` }}
+
+    @tr{@td{@code`(look offset patt)` }
+        @td{ Matches only if patt matches at a fixed offset. offset can be any
+        integer. patt will not produce captures and the peg will not advance any
+        characters. }}
+
+    @tr{@td{@code`(> offset patt)` }
+        @td{ Alias for @code`(look offset patt)` }}
+
+    @tr{@td{@code`(opt patt)` }
+        @td{ Alias for @code`(between 0 1 patt)` }}
+
+    @tr{@td{@code`(? patt)` }
+        @td{ Alias for @code`(between 0 1 patt)` }}}
+
+PEGs try to match an input text with a pattern in a greedy manner.  This means
+that if a rule fails to match, that rule will fail and not try again. The only
+backtracking provided in a PEG is provided by the @code`(choice x y z ...)`
+special, which will try rules in order until one succeeds, and the whole pattern
+succeeds. If no sub-pattern succeeds, then the whole pattern fails. Note that
+this means that the order of @code`x y z` in choice @strong{does} matter. If
+@code`y` matches everything that @code`z` matches, @code`z` will never succeed.
 
 ## Captures
 
-So far we have only been concerned with "does this text match this language?". This is useful, but
-it is often more useful to extract data from text if it does match a PEG. The @code`peg` module
-uses that concept of a capture stack to extract data from text. As the PEG is trying to match
-a piece of text, some forms may push Janet values onto the capture stack as a side effect. If the
-text matches the main PEG language, @code`(peg/match)` will return the final capture stack as an array.
+So far we have only been concerned with "does this text match this language?".
+This is useful, but it is often more useful to extract data from text if it does
+match a PEG. The @code`peg` module uses that concept of a capture stack to
+extract data from text. As the PEG is trying to match a piece of text, some
+forms may push Janet values onto the capture stack as a side effect. If the text
+matches the main PEG language, @code`(peg/match)` will return the final capture
+stack as an array.
 
-Capture specials will only push captures to the capture stack if their child pattern matches the text.
-Most captures specials will match the same text as their first argument pattern. In addition, most specials
-that produce captures can take an optional argument @code`tag` that applies a keyword tag to the capture.
-These tagged captures can then be recaptured via the @code`(backref tag)` special in subsequent matches.
-Tagged captures, when combined with the @code`(cmt)` special, provide a powerful form of look-behind
-that can make many grammars simpler.
+Capture specials will only push captures to the capture stack if their child
+pattern matches the text.  Most captures specials will match the same text as
+their first argument pattern. In addition, most specials that produce captures
+can take an optional argument @code`tag` that applies a keyword tag to the
+capture.  These tagged captures can then be recaptured via the @code`(backref
+tag)` special in subsequent matches.  Tagged captures, when combined with the
+@code`(cmt)` special, provide a powerful form of look-behind that can make many
+grammars simpler.
 
 @tag[table]{
-    @tr{@th{Pattern Signature} @th{What it matches}}
-    @tr{@td{@code`(capture patt ?tag)` } @td{ Captures all of the text in patt if patt matches, If patt contains any captures, then those captures will be pushed to the capture stack before the total text. }}
-    @tr{@td{@code`(<- patt ?tag)` } @td{ Alias for @code`(capture patt ?tag)` }}
-    @tr{@td{@code`(quote patt ?tag)` } @td{ Another alias for @code`(capture patt ?tag)`. This allows code like @code`'patt` to capture a pattern. }}
-    @tr{@td{@code`(group patt ?tag) ` } @td{ Captures an array of all of the captures in patt. }}
-    @tr{@td{@code`(replace patt subst ?tag)` } @td{ Replaces the captures produced by patt by applying subst to them. If subst is a table or struct, will push @code`(get subst last-capture)` to the capture stack after removing the old captures. If a subst is a function, will call subst with the captures of patt as arguments and push the result to the capture stack. Otherwise, will push subst literally to the capture stack. }}
-    @tr{@td{@code`(/ patt subst ?tag)` } @td{ Alias for @code`(replace patt subst ?tag)` }}
-    @tr{@td{@code`(constant k ?tag)` } @td{ Captures a constant value and advances no characters. }}
-    @tr{@td{@code`(argument n ?tag)` } @td{ Captures the nth extra argument to the match function and does not advance. }}
-    @tr{@td{@code`(position ?tag)` } @td{ Captures the current index into the text and advances no input. }}
-    @tr{@td{@code`($ ?tag)` } @td{ Alias for @code`(position ?tag)`. }}
-    @tr{@td{@code`(accumulate patt ?tag)` } @td{ Capture a string that is the concatenation of all captures in patt. This will try to be efficient and not create intermediate strings if possible. }}
-    @tr{@td{@code`(% patt ?tag)` } @td{ Alias for @code`(accumulate patt ?tag)` }}
-    @tr{@td{@code`(cmt patt fun ?tag)` } @td{ Invokes fun with all of the captures of patt as arguments (if patt matches). If the result is truthy, then captures the result. The whole expression fails if fun returns false or nil. }}
-    @tr{@td{@code`(backref tag ?tag)` } @td{ Duplicates the last capture with the tag @code`tag`. If no such capture exists then the match fails. }}
-    @tr{@td{@code`(-> tag ?tag)` } @td{ Alias for @code`(backref tag)`. }}
-    @tr{@td{@code`(error patt)` } @td{ Throws a Janet error if patt matches. The error thrown will be the last capture of patt, or a generic error if patt produces no captures. }}
-    @tr{@td{@code`(drop patt)` } @td{ Ignores (drops) all captures from patt. }}
-    @tr{@td{@code`(lenprefix n patt)` } @td{ Matches n repetitions of a pattern, where n is supplied from other parsed input and is not a constant. }}}
+    @tr{@th{Pattern Signature}
+        @th{What it matches}}
+
+    @tr{@td{@code`(capture patt ?tag)` }
+        @td{ Captures all of the text in patt if patt matches, If patt contains
+        any captures, then those captures will be pushed to the capture stack
+        before the total text. }}
+
+    @tr{@td{@code`(<- patt ?tag)` }
+        @td{ Alias for @code`(capture patt ?tag)` }}
+
+    @tr{@td{@code`(quote patt ?tag)` }
+        @td{ Another alias for @code`(capture patt ?tag)`. This allows code
+        like @code`'patt` to capture a pattern. }}
+
+    @tr{@td{@code`(group patt ?tag) ` }
+        @td{ Captures an array of all of the captures in patt. }}
+
+    @tr{@td{@code`(replace patt subst ?tag)` }
+        @td{ Replaces the captures produced by patt by applying subst to them.
+        If subst is a table or struct, will push @code`(get subst last-capture)`
+        to the capture stack after removing the old captures. If a subst is a
+        function, will call subst with the captures of patt as arguments and
+        push the result to the capture stack. Otherwise, will push subst
+        literally to the capture stack. }}
+
+    @tr{@td{@code`(/ patt subst ?tag)` }
+        @td{ Alias for @code`(replace patt subst ?tag)` }}
+
+    @tr{@td{@code`(constant k ?tag)` }
+        @td{ Captures a constant value and advances no characters. }}
+
+    @tr{@td{@code`(argument n ?tag)` }
+        @td{ Captures the nth extra argument to the match function and does not
+        advance. }}
+
+    @tr{@td{@code`(position ?tag)` }
+        @td{ Captures the current index into the text and advances no input. }}
+
+    @tr{@td{@code`($ ?tag)` }
+        @td{ Alias for @code`(position ?tag)`. }}
+
+    @tr{@td{@code`(accumulate patt ?tag)` }
+        @td{ Capture a string that is the concatenation of all captures in patt.
+        This will try to be efficient and not create intermediate strings if
+        possible. }}
+
+    @tr{@td{@code`(% patt ?tag)` }
+        @td{ Alias for @code`(accumulate patt ?tag)` }}
+
+    @tr{@td{@code`(cmt patt fun ?tag)` }
+        @td{ Invokes fun with all of the captures of patt as arguments (if patt
+        matches). If the result is truthy, then captures the result. The whole
+        expression fails if fun returns false or nil. }}
+
+    @tr{@td{@code`(backref tag ?tag)` }
+        @td{ Duplicates the last capture with the tag @code`tag`. If no such
+        capture exists then the match fails. }}
+
+    @tr{@td{@code`(-> tag ?tag)` }
+        @td{ Alias for @code`(backref tag)`. }}
+
+    @tr{@td{@code`(error patt)` }
+        @td{ Throws a Janet error if patt matches. The error thrown will be the
+        last capture of patt, or a generic error if patt produces no captures.
+        }}
+
+    @tr{@td{@code`(drop patt)` }
+        @td{ Ignores (drops) all captures from patt. }}
+
+    @tr{@td{@code`(lenprefix n patt)` }
+        @td{ Matches n repetitions of a pattern, where n is supplied from other
+        parsed input and is not a constant. }}}
 
 ## Grammars and recursion
 
-The feature that makes PEGs so much more powerful than pattern matching solutions like (vanilla) regex is mutual recursion.
-To do recursion in a PEG, you can wrap multiple patterns in a grammar, which is a Janet struct. The patterns must be named by
-keywords, which can then be used in all sub-patterns in the grammar.
+The feature that makes PEGs so much more powerful than pattern matching
+solutions like (vanilla) regex is mutual recursion.  To do recursion in a PEG,
+you can wrap multiple patterns in a grammar, which is a Janet struct. The
+patterns must be named by keywords, which can then be used in all sub-patterns
+in the grammar.
 
-Each grammar, defined by a struct, must also have a main rule, called @code`:main`, that is the pattern that the entire grammar
-is defined by.
+Each grammar, defined by a struct, must also have a main rule, called
+@code`:main`, that is the pattern that the entire grammar is defined by.
 
 An example grammar that uses mutual recursion:
 
@@ -185,18 +305,19 @@ An example grammar that uses mutual recursion:
 (peg/match my-grammar "(babaabab)") # -> nil
 ```
 
-Keep in mind that recursion is implemented with a stack, meaning that very recursive grammars
-can overflow the stack. The compiler is able to turn some recursion into iteration via tail-call optimization, but some patterns
-may fail on large inputs. It is also possible to construct (very poorly written) patterns that will result in long loops and be very
-slow in general.
+Keep in mind that recursion is implemented with a stack, meaning that very
+recursive grammars can overflow the stack. The compiler is able to turn some
+recursion into iteration via tail-call optimization, but some patterns may fail
+on large inputs. It is also possible to construct (very poorly written) patterns
+that will result in long loops and be very slow in general.
 
 ## Built-in patterns
 
-Besides the primitive patterns and pattern combinators given above, the @code`peg` module also
-provides a default grammar with a handful of commonly used patterns. All of these shorthands
-can be defined with the combinators above and primitive patterns, but you may
-see these aliases in other grammars and they can make grammar simpler and easier
-to read.
+Besides the primitive patterns and pattern combinators given above, the
+@code`peg` module also provides a default grammar with a handful of commonly
+used patterns. All of these shorthands can be defined with the combinators above
+and primitive patterns, but you may see these aliases in other grammars and they
+can make grammar simpler and easier to read.
 
 @tag[table]{
     @tr{@th{Name} @th{Expanded} @th{Description}}
@@ -221,17 +342,18 @@ to read.
     @tr{@td{@code`:s*`} @td{@code`(any :s)`} @td{Matches 0 ore mote ASCII whitespace characters.}}
 }
 
-All of these aliases are defined in @code`default-peg-grammar`, which is a table that maps
-from the alias name to the expanded form. You can even add your own aliases here which are then
-available for all PEGs in the program. Modifiying this table will not affect
-already compiled PEGs.
+All of these aliases are defined in @code`default-peg-grammar`, which is a table
+that maps from the alias name to the expanded form. You can even add your own
+aliases here which are then available for all PEGs in the program. Modifiying
+this table will not affect already compiled PEGs.
 
 ## String searching and other idioms
 
-Although all pattern matching is done in anchored mode, operations like global substitution
-and searching can be implemented with the PEG module. A simple Janet function that produces PEGs
-that search for strings shows how captures and looping specials can composed, and how quasiquoting
-can be used to embed values in patterns.
+Although all pattern matching is done in anchored mode, operations like global
+substitution and searching can be implemented with the PEG module. A simple
+Janet function that produces PEGs that search for strings shows how captures and
+looping specials can composed, and how quasiquoting can be used to embed values
+in patterns.
 
 @codeblock[janet]```
 (defn finder
@@ -250,8 +372,8 @@ can be used to embed values in patterns.
 (peg/match find-cats "cat ct caat caaaaat cat") # -> @[0 7 12 20]
 ```
 
-We can also wrap a PEG to turn it into a global substitution grammar with
-the accumulate special @code`(%)`.
+We can also wrap a PEG to turn it into a global substitution grammar with the
+accumulate special @code`(%)`.
 
 @codeblock[janet]```
 (defn replacer

--- a/content/docs/prototypes.mdz
+++ b/content/docs/prototypes.mdz
@@ -3,10 +3,10 @@
  :order 16}
 ---
 
-To support basic generic programming, Janet tables support a prototype
-table. A prototype table contains default values for a table if certain keys
-are not found in the original table. This allows many similar tables to share
-contents without duplicating memory.
+To support basic generic programming, Janet tables support a prototype table. A
+prototype table contains default values for a table if certain keys are not
+found in the original table. This allows many similar tables to share contents
+without duplicating memory.
 
 @codeblock[janet]```
 # Simple Object Oriented behavior in Janet
@@ -25,19 +25,24 @@ contents without duplicating memory.
 (:behave thing2 :b) # prints "behaving 2 :b"
 ```
 
-Looking up a value in a table with a prototype can be summed up with the following algorithm.
+Looking up a value in a table with a prototype can be summed up with the
+following algorithm.
 
 @ol{@li{@code`(get my-table my-key)` is called.}
-    @li{@code`my-table` is checked for the key @code`my-key`. If there is a value for the key, it is returned.}
-    @li{If there is a prototype table for @code`my-table`, set `my-table` = `my-table's prototype` and go to 2. Otherwise go to 4.}
+    @li{@code`my-table` is checked for the key @code`my-key`. If there is a value
+         for the key, it is returned.}
+    @li{If there is a prototype table for @code`my-table`, set @code`my-table` =
+        @code`my-table's prototype` and go to 2. Otherwise go to 4.}
     @li{Return @code`nil` as the key was not found.}}
 
-Janet will check up to about a 1000 prototypes recursively by default before giving up and returning @code`nil`. This
-is to prevent an infinite loop. This value can be changed by adjusting the @code`JANET_RECURSION_GUARD` value
-in @code`janet.h`.
+Janet will check up to about a 1000 prototypes recursively by default before
+giving up and returning @code`nil`. This is to prevent an infinite loop. This
+value can be changed by adjusting the @code`JANET_RECURSION_GUARD` value in
+@code`janet.h`.
 
-Note that Janet prototypes are not as expressive as metatables in Lua and many other languages.
-This is by design, as adding Lua- or Python-like capabilities would not be technically difficult.
-Users should prefer plain data and functions that operate on them rather than mutable objects
-with methods. However, some object-oriented capabilities are useful in Janet for
-systems that require extra flexibility.
+Note that Janet prototypes are not as expressive as metatables in Lua and many
+other languages.  This is by design, as adding Lua- or Python-like capabilities
+would not be technically difficult.  Users should prefer plain data and
+functions that operate on them rather than mutable objects with methods.
+However, some object-oriented capabilities are useful in Janet for systems that
+require extra flexibility.

--- a/content/docs/prototypes.mdz
+++ b/content/docs/prototypes.mdz
@@ -28,16 +28,16 @@ contents without duplicating memory.
 Looking up a value in a table with a prototype can be summed up with the following algorithm.
 
 @ol{@li{@code`(get my-table my-key)` is called.}
-    @li{my-table is checked for the key if my-key. If there is a value for the key, it is returned.}
-    @li{If there is a prototype table for my-table, set `my-table` = `my-table's prototype` and go to 2. Otherwise go to 4.}
-    @li{Return nil as the key was not found.}}
+    @li{@code`my-table` is checked for the key @code`my-key`. If there is a value for the key, it is returned.}
+    @li{If there is a prototype table for @code`my-table`, set `my-table` = `my-table's prototype` and go to 2. Otherwise go to 4.}
+    @li{Return @code`nil` as the key was not found.}}
 
-Janet will check up to about a 1000 prototypes recursively by default before giving up and returning nil. This
+Janet will check up to about a 1000 prototypes recursively by default before giving up and returning @code`nil`. This
 is to prevent an infinite loop. This value can be changed by adjusting the @code`JANET_RECURSION_GUARD` value
-in janet.h.
+in @code`janet.h`.
 
 Note that Janet prototypes are not as expressive as metatables in Lua and many other languages.
-This is by design, as adding Lua or Python like capabilities would not be technically difficult.
+This is by design, as adding Lua- or Python-like capabilities would not be technically difficult.
 Users should prefer plain data and functions that operate on them rather than mutable objects
-with methods. However, some Object Oriented capabilities are useful in Janet for
+with methods. However, some object-oriented capabilities are useful in Janet for
 systems that require extra flexibility.

--- a/content/docs/specials.mdz
+++ b/content/docs/specials.mdz
@@ -9,14 +9,14 @@ Tuples are used to represent function calls, macros,
 and special forms. Most functionality is exposed through functions, some
 through macros, and a minimal amount through special forms. Special forms
 are neither functions nor macros @html`&mdash;` they are used by the compiler to directly
-express a low level construct that can not be expressed through macros or functions.
+express a low-level construct that cannot be expressed through macros or functions.
 Special forms can be thought of as forming the real 'core' language of Janet. There are
 only 12 special forms in Janet.
 
 ## @code`(def name meta... value)`
 
 This special form binds a value to a symbol. The symbol can be substituted
-for the value in subsequent expressions for the same result. A binding made by def
+for the value in subsequent expressions for the same result. A binding made by @code`def`
 is a constant and cannot be updated. A symbol can be redefined to a new value, but previous
 uses of the binding will refer to the previous value of the binding.
 
@@ -26,8 +26,8 @@ uses of the binding will refer to the previous value of the binding.
 (print anumber) # prints 15
 ```
 
-Def can also take a tuple, array, table or struct to perform destructuring
-on the value. This allows us to do multiple assignments in one def.
+@p{@code`def` can also take a tuple, array, table or struct to perform destructuring
+on the value. This allows us to do multiple assignments in one @code`def`.}
 
 @codeblock[janet]```
 (def [a b c] (range 10))
@@ -40,8 +40,8 @@ on the value. This allows us to do multiple assignments in one def.
 (print y x) # prints hi3
 ```
 
-Def can also append metadata and a docstring to the symbol when in the global scope.
-If not in the global scope, the extra metadata will be ignored.
+@p{@code`def` can also append metadata and a docstring to the symbol when in the global scope.
+If not in the global scope, the extra metadata will be ignored.}
 
 @codeblock[janet]```
 (def mydef :private 3) # Adds the :private key to the metadata table.
@@ -56,8 +56,8 @@ If not in the global scope, the extra metadata will be ignored.
 
 ## @code`(var name meta... value)`
 
-Similar to def, but bindings set in this manner can be updated using set. In all other respects it is the
-same as def.
+Similar to @code`def`, but bindings set in this manner can be updated using set. In all other respects it is the
+same as @code`def`.
 
 @codeblock[janet]```
 (var a 1)
@@ -78,7 +78,7 @@ more easily be recursive. The argument list is a tuple of named parameters, and 
 is 0 or more forms. The function will evaluate to the last form in the body. The other forms
 will only be evaluated for side effects.
 
-Functions also introduce a new lexical scope, meaning the defs and vars inside a function
+Functions also introduce a new lexical scope, meaning the @code`def`s and @code`var`s inside a function
 body will not escape outside the body.
 
 @codeblock[janet]```
@@ -95,7 +95,8 @@ body will not escape outside the body.
 (fn [w x y z &] (tuple w w x x y y z z))
 ```
 
-For more information on functions, see @link[/docs/functions.html][/docs/functions.html].
+For more information on functions, see the @link[/docs/functions.html][Functions
+section].
 
 ## @code`(do body...)`
 
@@ -121,7 +122,7 @@ a
 
 Evaluates to the literal value of the first argument. The argument is not compiled
 and is simply used as a constant value in the compiled code. Preceding a form with a
-single quote is shorthand for `(quote expression)`.
+single quote is shorthand for @code`(quote expression)`.
 
 @codeblock[janet]```
 (quote 1) # evaluates to 1
@@ -137,13 +138,13 @@ single quote is shorthand for `(quote expression)`.
 Introduce a branching construct. The first form is the condition, the second
 form is the form to evaluate when the condition is true, and the optional
 third form is the form to evaluate when the condition is false. If no third
-form is provided it defaults to nil.
+form is provided it defaults to @code`nil`.
 
-The if special form will not evaluate the when-true or when-false forms unless
+The @code`if` special form will not evaluate the when-true or when-false forms unless
 it needs to - it is a lazy form, which is why it cannot be a function or macro.
 
-The condition is considered false only if it evaluates to nil or false - all other values
-are considered true.
+The condition is considered false only if it evaluates to @code`nil` or @code`false` - all other values
+are considered @code`true`.
 
 @codeblock[janet]```
 (if true 10) # evaluates to 10
@@ -156,16 +157,17 @@ are considered true.
 
 ## @code`(splice x)`
 
-The splice special form is an interesting form that allows putting an array or tuple
-into a form inline.
+The @code`splice` special form is an interesting form that allows an array or tuple
+to be put into another form inline.
 It only has an effect in two places - as an argument in a function call or literal
 constructor, or as the argument
 to the unquote form. Outside of these two settings, the splice special form simply evaluates
-directly to its argument x. The shorthand for splice is prefixing a form with a semicolon. The
-splice special form will also have no effect in the behavior of other special forms, except as an
+directly to its argument @code`x`. The shorthand for @code`splice` is prefixing a form with a semicolon. The
+@code`splice` special form has no effect on the behavior of other special forms, except as an
 argument to @code`unquote`.
 
-In the context of a function call, splice will insert @em{the contents} of x in the parameter list.
+In the context of a function call, @code`splice` will insert @em{the contents}
+of @code`x` in the parameter list.
 
 @codeblock[janet]```
 (+ 1 2 3) # evaluates to 6
@@ -185,17 +187,17 @@ In the context of a function call, splice will insert @em{the contents} of x in 
 (def ;[a 10]) # this will not work as def is a special form.
 ```
 
-Notice that this means we rarely will need the @code`apply` function, as the splice operator is more flexible.
+Notice that this means we rarely need the @code`apply` function, as the @code`splice` operator is more flexible.
 
-A splice form can also be used as the argument to an unquote form, where it will behave like
+A @code`splice` form can also be used as the argument to an @code`unquote` form, where it will behave like
 an @code`unquote-splicing` special in Common Lisp. Using the short form of both of these
 specials, this can be abbreviated @code`,;some-array-expression`.
 
 ## @code`(while condition body...)`
 
-The while special form compiles to a C-like while loop. The body of the form will be continuously evaluated
-until the condition is false or nil. Therefore, it is expected that the body will contain some side effects
-or the loop will go on forever. The while loop always evaluates to nil.
+The @code`while` special form compiles to a C-like @code`while` loop. The body of the form will be continuously evaluated
+until the condition is @code`false` or @code`nil`. Therefore, it is expected that the body will contain some side effects
+or the loop will go on forever. The @code`while` loop always evaluates to @code`nil`.
 
 @codeblock[janet]```
 (var i 0)
@@ -206,13 +208,13 @@ or the loop will go on forever. The while loop always evaluates to nil.
 
 ## @code`(break value?)`
 
-Break from a while loop or return early from a function. The break special form can only
-break from the inner-most loop. Since a while loop always returns nil, the optional `value`
-parameter has no effect when used in a while loop, but when returning from a function, the
-value parameter is the function's return value.
+Break from a @code`while` loop or return early from a function. The @code`break` special form can only
+break from the inner-most loop. Since a @code`while` loop always returns @code`nil`, the optional `value`
+parameter has no effect when used in a @code`while` loop, but when returning from a function, the
+@code`value` parameter is the function's return value.
 
 The @code`break` special form is most useful as a low level construct for macros. You should
-try to avoid using it in hand written code, although it can be very useful for handling
+try to avoid using it in handwritten code, although it can be very useful for handling
 early exit conditions without requiring deeply indented code (try the @code`cond` macro first, though).
 
 @codeblock[janet]```
@@ -247,9 +249,10 @@ early exit conditions without requiring deeply indented code (try the @code`cond
 
 ## @code`(set l-value r-value)`
 
-Update the value of a var l-value to a new value r-value. The set special form will then evaluate to r-value.
+Update the value of the var @code`l-value` with the new @code`r-value`. The
+@code`set` special form will then evaluate to @code`r-value`.
 
-The r-value can be any expression, and the l-value should be a bound var or a pair of
+The @code`r-value` can be any expression, and the @code`l-value` should be a bound var or a pair of
 a data structure and key. This allows set to behave like @code`setf` or @code`setq` in Common Lisp.
 
 @codeblock[janet]```
@@ -268,12 +271,12 @@ a data structure and key. This allows set to behave like @code`setf` or @code`se
 
 ## @code`(quasiquote x)`
 
-Similar to @code`(quote x)`, but allows for unquoting within x. This makes quasiquote useful for
+Similar to @code`(quote x)`, but allows for unquoting within @code`x`. This makes @code`quasiquote` useful for
 writing macros, as a macro definition often generates a lot of templated code with a
 few custom values. The shorthand for quasiquote is a leading tilde @code`~` before a form. With
-that form, @code`(unquote x)` will evaluate and insert x into the unquote form. The shorthand for
+that form, @code`(unquote x)` will evaluate and insert @code`x` into the @code`unquote` form. The shorthand for
 @code`(unquote x)` is @code`,x`.
 
 ## @code`(unquote x)`
 
-Unquote a form within a quasiquote. Outside of a quasiquote, unquote is invalid.
+Unquote a form within a @code`quasiquote`. Outside of a @code`quasiquote`, @code`unquote` is invalid.

--- a/content/docs/specials.mdz
+++ b/content/docs/specials.mdz
@@ -5,20 +5,21 @@
 
 This document serves as an overview of all of the special forms in Janet.
 
-Tuples are used to represent function calls, macros,
-and special forms. Most functionality is exposed through functions, some
-through macros, and a minimal amount through special forms. Special forms
-are neither functions nor macros @html`&mdash;` they are used by the compiler to directly
-express a low-level construct that cannot be expressed through macros or functions.
-Special forms can be thought of as forming the real 'core' language of Janet. There are
-only 12 special forms in Janet.
+Tuples are used to represent function calls, macros, and special forms. Most
+functionality is exposed through functions, some through macros, and a minimal
+amount through special forms. Special forms are neither functions nor macros
+@html`&mdash;` they are used by the compiler to directly express a low-level
+construct that cannot be expressed through macros or functions.  Special forms
+can be thought of as forming the real 'core' language of Janet. There are only
+12 special forms in Janet.
 
 ## @code`(def name meta... value)`
 
-This special form binds a value to a symbol. The symbol can be substituted
-for the value in subsequent expressions for the same result. A binding made by @code`def`
-is a constant and cannot be updated. A symbol can be redefined to a new value, but previous
-uses of the binding will refer to the previous value of the binding.
+This special form binds a value to a symbol. The symbol can be substituted for
+the value in subsequent expressions for the same result. A binding made by
+@code`def` is a constant and cannot be updated. A symbol can be redefined to a
+new value, but previous uses of the binding will refer to the previous value of
+the binding.
 
 @codeblock[janet]```
 (def anumber (+ 1 2 3 4 5))
@@ -26,8 +27,9 @@ uses of the binding will refer to the previous value of the binding.
 (print anumber) # prints 15
 ```
 
-@p{@code`def` can also take a tuple, array, table or struct to perform destructuring
-on the value. This allows us to do multiple assignments in one @code`def`.}
+@p{@code`def` can also take a tuple, array, table or struct to perform
+    destructuring on the value. This allows us to do multiple assignments in one
+    @code`def`.}
 
 @codeblock[janet]```
 (def [a b c] (range 10))
@@ -40,8 +42,9 @@ on the value. This allows us to do multiple assignments in one @code`def`.}
 (print y x) # prints hi3
 ```
 
-@p{@code`def` can also append metadata and a docstring to the symbol when in the global scope.
-If not in the global scope, the extra metadata will be ignored.}
+@p{@code`def` can also append metadata and a docstring to the symbol when in the
+    global scope.  If not in the global scope, the extra metadata will be
+    ignored.}
 
 @codeblock[janet]```
 (def mydef :private 3) # Adds the :private key to the metadata table.
@@ -56,8 +59,8 @@ If not in the global scope, the extra metadata will be ignored.}
 
 ## @code`(var name meta... value)`
 
-Similar to @code`def`, but bindings set in this manner can be updated using set. In all other respects it is the
-same as @code`def`.
+Similar to @code`def`, but bindings set in this manner can be updated using set.
+In all other respects it is the same as @code`def`.
 
 @codeblock[janet]```
 (var a 1)
@@ -72,14 +75,15 @@ same as @code`def`.
 
 ## @code`(fn name? args body...)`
 
-Compile a function literal (closure). A function literal consists of an optional name, an
-argument list, and a function body. The optional name is allowed so that functions can
-more easily be recursive. The argument list is a tuple of named parameters, and the body
-is 0 or more forms. The function will evaluate to the last form in the body. The other forms
-will only be evaluated for side effects.
+Compile a function literal (closure). A function literal consists of an optional
+name, an argument list, and a function body. The optional name is allowed so
+that functions can more easily be recursive. The argument list is a tuple of
+named parameters, and the body is 0 or more forms. The function will evaluate to
+the last form in the body. The other forms will only be evaluated for side
+effects.
 
-Functions also introduce a new lexical scope, meaning the @code`def`s and @code`var`s inside a function
-body will not escape outside the body.
+Functions also introduce a new lexical scope, meaning the @code`def`s and
+@code`var`s inside a function body will not escape outside the body.
 
 @codeblock[janet]```
 (fn []) # The simplest function literal. Takes no arguments and returns nil.
@@ -120,9 +124,9 @@ a
 
 ## @code`(quote x)`
 
-Evaluates to the literal value of the first argument. The argument is not compiled
-and is simply used as a constant value in the compiled code. Preceding a form with a
-single quote is shorthand for @code`(quote expression)`.
+Evaluates to the literal value of the first argument. The argument is not
+compiled and is simply used as a constant value in the compiled code. Preceding
+a form with a single quote is shorthand for @code`(quote expression)`.
 
 @codeblock[janet]```
 (quote 1) # evaluates to 1
@@ -136,15 +140,16 @@ single quote is shorthand for @code`(quote expression)`.
 ## @code`(if condition when-true when-false?)`
 
 Introduce a branching construct. The first form is the condition, the second
-form is the form to evaluate when the condition is true, and the optional
-third form is the form to evaluate when the condition is false. If no third
-form is provided it defaults to @code`nil`.
+form is the form to evaluate when the condition is true, and the optional third
+form is the form to evaluate when the condition is false. If no third form is
+provided it defaults to @code`nil`.
 
-The @code`if` special form will not evaluate the when-true or when-false forms unless
-it needs to - it is a lazy form, which is why it cannot be a function or macro.
+The @code`if` special form will not evaluate the when-true or when-false forms
+unless it needs to - it is a lazy form, which is why it cannot be a function or
+macro.
 
-The condition is considered false only if it evaluates to @code`nil` or @code`false` - all other values
-are considered @code`true`.
+The condition is considered false only if it evaluates to @code`nil` or
+@code`false` - all other values are considered @code`true`.
 
 @codeblock[janet]```
 (if true 10) # evaluates to 10
@@ -157,14 +162,13 @@ are considered @code`true`.
 
 ## @code`(splice x)`
 
-The @code`splice` special form is an interesting form that allows an array or tuple
-to be put into another form inline.
-It only has an effect in two places - as an argument in a function call or literal
-constructor, or as the argument
-to the unquote form. Outside of these two settings, the splice special form simply evaluates
-directly to its argument @code`x`. The shorthand for @code`splice` is prefixing a form with a semicolon. The
-@code`splice` special form has no effect on the behavior of other special forms, except as an
-argument to @code`unquote`.
+The @code`splice` special form is an interesting form that allows an array or
+tuple to be put into another form inline.  It only has an effect in two places -
+as an argument in a function call or literal constructor, or as the argument to
+the unquote form. Outside of these two settings, the splice special form simply
+evaluates directly to its argument @code`x`. The shorthand for @code`splice` is
+prefixing a form with a semicolon. The @code`splice` special form has no effect
+on the behavior of other special forms, except as an argument to @code`unquote`.
 
 In the context of a function call, @code`splice` will insert @em{the contents}
 of @code`x` in the parameter list.
@@ -187,17 +191,21 @@ of @code`x` in the parameter list.
 (def ;[a 10]) # this will not work as def is a special form.
 ```
 
-Notice that this means we rarely need the @code`apply` function, as the @code`splice` operator is more flexible.
+Notice that this means we rarely need the @code`apply` function, as the
+@code`splice` operator is more flexible.
 
-A @code`splice` form can also be used as the argument to an @code`unquote` form, where it will behave like
-an @code`unquote-splicing` special in Common Lisp. Using the short form of both of these
-specials, this can be abbreviated @code`,;some-array-expression`.
+A @code`splice` form can also be used as the argument to an @code`unquote` form,
+where it will behave like an @code`unquote-splicing` special in Common Lisp.
+Using the short form of both of these specials, this can be abbreviated
+@code`,;some-array-expression`.
 
 ## @code`(while condition body...)`
 
-The @code`while` special form compiles to a C-like @code`while` loop. The body of the form will be continuously evaluated
-until the condition is @code`false` or @code`nil`. Therefore, it is expected that the body will contain some side effects
-or the loop will go on forever. The @code`while` loop always evaluates to @code`nil`.
+The @code`while` special form compiles to a C-like @code`while` loop. The body
+of the form will be continuously evaluated until the condition is @code`false`
+or @code`nil`. Therefore, it is expected that the body will contain some side
+effects or the loop will go on forever. The @code`while` loop always evaluates
+to @code`nil`.
 
 @codeblock[janet]```
 (var i 0)
@@ -208,14 +216,16 @@ or the loop will go on forever. The @code`while` loop always evaluates to @code`
 
 ## @code`(break value?)`
 
-Break from a @code`while` loop or return early from a function. The @code`break` special form can only
-break from the inner-most loop. Since a @code`while` loop always returns @code`nil`, the optional `value`
-parameter has no effect when used in a @code`while` loop, but when returning from a function, the
+Break from a @code`while` loop or return early from a function. The @code`break`
+special form can only break from the inner-most loop. Since a @code`while` loop
+always returns @code`nil`, the optional `value` parameter has no effect when
+used in a @code`while` loop, but when returning from a function, the
 @code`value` parameter is the function's return value.
 
-The @code`break` special form is most useful as a low level construct for macros. You should
-try to avoid using it in handwritten code, although it can be very useful for handling
-early exit conditions without requiring deeply indented code (try the @code`cond` macro first, though).
+The @code`break` special form is most useful as a low level construct for
+macros. You should try to avoid using it in handwritten code, although it can be
+very useful for handling early exit conditions without requiring deeply indented
+code (try the @code`cond` macro first, though).
 
 @codeblock[janet]```
 # Breaking from a while loop
@@ -252,8 +262,9 @@ early exit conditions without requiring deeply indented code (try the @code`cond
 Update the value of the var @code`l-value` with the new @code`r-value`. The
 @code`set` special form will then evaluate to @code`r-value`.
 
-The @code`r-value` can be any expression, and the @code`l-value` should be a bound var or a pair of
-a data structure and key. This allows set to behave like @code`setf` or @code`setq` in Common Lisp.
+The @code`r-value` can be any expression, and the @code`l-value` should be a
+bound var or a pair of a data structure and key. This allows set to behave like
+@code`setf` or @code`setq` in Common Lisp.
 
 @codeblock[janet]```
 (var x 10)
@@ -271,12 +282,14 @@ a data structure and key. This allows set to behave like @code`setf` or @code`se
 
 ## @code`(quasiquote x)`
 
-Similar to @code`(quote x)`, but allows for unquoting within @code`x`. This makes @code`quasiquote` useful for
-writing macros, as a macro definition often generates a lot of templated code with a
-few custom values. The shorthand for quasiquote is a leading tilde @code`~` before a form. With
-that form, @code`(unquote x)` will evaluate and insert @code`x` into the @code`unquote` form. The shorthand for
-@code`(unquote x)` is @code`,x`.
+Similar to @code`(quote x)`, but allows for unquoting within @code`x`. This
+makes @code`quasiquote` useful for writing macros, as a macro definition often
+generates a lot of templated code with a few custom values. The shorthand for
+quasiquote is a leading tilde @code`~` before a form. With that form,
+@code`(unquote x)` will evaluate and insert @code`x` into the @code`unquote`
+form. The shorthand for @code`(unquote x)` is @code`,x`.
 
 ## @code`(unquote x)`
 
-Unquote a form within a @code`quasiquote`. Outside of a @code`quasiquote`, @code`unquote` is invalid.
+Unquote a form within a @code`quasiquote`. Outside of a @code`quasiquote`,
+@code`unquote` is invalid.

--- a/content/docs/strings.mdz
+++ b/content/docs/strings.mdz
@@ -10,10 +10,7 @@ characters. For example, @code`:hello`, @code`:my-name`, @code`::`, and @code`:A
 
 Keywords, symbols, and strings all behave similarly and can be used as keys for tables and structs.
 Symbols and keywords are optimized for fast equality checks, so are preferred for table keys.
-
-The difference between symbols and keywords is that keywords evaluate to themselves, while
-symbols evaluate to whatever they are bound to. To have a symbol evaluate to itself, it must be
-quoted.
+Keywords, symbols, and strings are all immutable.
 
 @codeblock[janet]```
 # Evaluates to :monday
@@ -32,9 +29,10 @@ monday
 monday
 ```
 
+## Keywords
+
 The most common thing to do with a keyword is to check it for equality or use it as a key into
-a table or struct. Note that symbols, keywords and strings are all immutable. Besides making your
-code easier to reason about, it allows for many optimizations involving these types.
+a table or struct.
 
 @codeblock[janet]```
 # Evaluates to true
@@ -51,11 +49,19 @@ code easier to reason about, it allows for many optimizations involving these ty
 } :age)
 ```
 
+## Symbols
+
+The difference between symbols and keywords is that keywords evaluate to themselves, while
+symbols evaluate to whatever they are bound to. To have a symbol evaluate to itself, it must be
+quoted.
+
+## Strings
+
 Strings can be used similarly to keywords, but their primary usage is for defining either text
-or arbitrary sequences of bytes. Strings (and symbols) in janet are what is sometimes known as
+or arbitrary sequences of bytes. Strings (and symbols) in Janet are what is sometimes known as
 ˝8-bit clean˝; they can hold any number of bytes, and are completely unaware of things like character
 encodings. This is completely compatible with ASCII and UTF-8, two of the most common character
-encodings. By being encoding agnostic, janet strings can be simple, fast, and useful
+encodings. By being encoding agnostic, Janet strings can be simple, fast, and useful
 for other uses besides holding text.
 
 Literal text can be entered inside quotes, as we have seen above.
@@ -77,14 +83,14 @@ Line 2
 ``
 ```
 
-Strings, symbols, and keywords can all contain embedded utf-8. It is recomended
-to embed utf-8 literally in strings rather than escaping it if it is printable.
+Strings, symbols, and keywords can all contain embedded UTF-8. It is recomended
+that you embed UTF-8 literally in strings rather than escaping it if it is printable.
 
 @codeblock[janet]```
 "Hello, 👍"
 ```
 
-## Substrings
+### Substrings
 
 The @code`string/slice` function is used to get substrings from a string. Negative
 integers can be used to index from the end of the string.
@@ -96,12 +102,12 @@ integers can be used to index from the end of the string.
 (string/slice "abcdefg" -4 -2) # -> "ef"
 ```
 
-## Finding Substrings
+### Finding substrings
 
 Janet has multiple functions for finding and replacing strings. The
 Janet string finding functions do not work on patterns or regular expressions;
 they only work on string literals. For more flexible searching and replacing, see
-the @link[/docs/peg.html][peg module].
+the @link[/docs/peg.html][PEG section].
 
 @codeblock[janet]```
 (string/find "h" "h h h h") #-> 0
@@ -110,18 +116,18 @@ the @link[/docs/peg.html][peg module].
 (string/replace-all "a" "b" "a a a a") #-> "b b b b"
 ```
 
-## Splitting Strings
+### Splitting strings
 
-The @code`string/split` function can be used to split strings or buffer on a delimiting
+The @code`string/split` function can be used to split strings or buffers on a delimiting
 character. This can be used as a quick and dirty function for getting fields
-from a csv line or getting words from a sentence.
+from a CSV line or words from a sentence.
 
 @codeblock[janet]```
 (string/split "," "abc,def,ghi") #-> @["abc" "def" "ghi"]
 (string/split " " "abc def ghi") #-> @["abc" "def" "ghi"]
 ```
 
-## Concatenating strings
+### Concatenating strings
 
 There are many ways to concatenate strings. The first, most common
 way is the @code`string` function, which takes any number of arguments and
@@ -143,18 +149,18 @@ the array. All items in the array or tuple must be byte sequences.
 
 This has the advantage over the @code`string` function that one can
 specify a separator. Otherwise, the behavior can be easily emulated
-using the splice special form.
+using the @code`splice` special form.
 
 @codeblock[janet]```
 (= (string ;@["a" "b" "c"])
    (string/join @["a" "b" "c"])) # -> true
 ```
 
-## Upper and lower case
+### Upper and lower case
 
 The string library also provides facilities for converting strings to
-upper case and lower case. However, only ascii is supported for case
-transformations. The functions @code`string/ascii-upper` and @code`string/ascii-lower`
+upper case and lower case. However, only ASCII characters will be transformed.
+The functions @code`string/ascii-upper` and @code`string/ascii-lower`
 return a new string that has all character in the appropriate case.
 
 @codeblock[janet]```

--- a/content/docs/strings.mdz
+++ b/content/docs/strings.mdz
@@ -3,14 +3,16 @@
  :order 7}
 ---
 
-Janet supports several varieties of types that can be used as labels for things in
-your program. The most useful type for this purpose is the keyword type. A keyword
-begins with a colon, and then contains 0 or more alphanumeric or a few other common
-characters. For example, @code`:hello`, @code`:my-name`, @code`::`, and @code`:ABC123_-*&^%$` are all keywords.
+Janet supports several varieties of types that can be used as labels for things
+in your program. The most useful type for this purpose is the keyword type. A
+keyword begins with a colon, and then contains 0 or more alphanumeric or a few
+other common characters. For example, @code`:hello`, @code`:my-name`, @code`::`,
+and @code`:ABC123_-*&^%$` are all keywords.
 
-Keywords, symbols, and strings all behave similarly and can be used as keys for tables and structs.
-Symbols and keywords are optimized for fast equality checks, so are preferred for table keys.
-Keywords, symbols, and strings are all immutable.
+Keywords, symbols, and strings all behave similarly and can be used as keys for
+tables and structs.  Symbols and keywords are optimized for fast equality
+checks, so are preferred for table keys.  Keywords, symbols, and strings are all
+immutable.
 
 @codeblock[janet]```
 # Evaluates to :monday
@@ -31,8 +33,8 @@ monday
 
 ## Keywords
 
-The most common thing to do with a keyword is to check it for equality or use it as a key into
-a table or struct.
+The most common thing to do with a keyword is to check it for equality or use it
+as a key into a table or struct.
 
 @codeblock[janet]```
 # Evaluates to true
@@ -51,18 +53,19 @@ a table or struct.
 
 ## Symbols
 
-The difference between symbols and keywords is that keywords evaluate to themselves, while
-symbols evaluate to whatever they are bound to. To have a symbol evaluate to itself, it must be
-quoted.
+The difference between symbols and keywords is that keywords evaluate to
+themselves, while symbols evaluate to whatever they are bound to. To have a
+symbol evaluate to itself, it must be quoted.
 
 ## Strings
 
-Strings can be used similarly to keywords, but their primary usage is for defining either text
-or arbitrary sequences of bytes. Strings (and symbols) in Janet are what is sometimes known as
-˝8-bit clean˝; they can hold any number of bytes, and are completely unaware of things like character
-encodings. This is completely compatible with ASCII and UTF-8, two of the most common character
-encodings. By being encoding agnostic, Janet strings can be simple, fast, and useful
-for other uses besides holding text.
+Strings can be used similarly to keywords, but their primary usage is for
+defining either text or arbitrary sequences of bytes. Strings (and symbols) in
+Janet are what is sometimes known as ˝8-bit clean˝; they can hold any number of
+bytes, and are completely unaware of things like character encodings. This is
+completely compatible with ASCII and UTF-8, two of the most common character
+encodings. By being encoding agnostic, Janet strings can be simple, fast, and
+useful for other uses besides holding text.
 
 Literal text can be entered inside quotes, as we have seen above.
 
@@ -84,7 +87,8 @@ Line 2
 ```
 
 Strings, symbols, and keywords can all contain embedded UTF-8. It is recomended
-that you embed UTF-8 literally in strings rather than escaping it if it is printable.
+that you embed UTF-8 literally in strings rather than escaping it if it is
+printable.
 
 @codeblock[janet]```
 "Hello, 👍"
@@ -92,8 +96,8 @@ that you embed UTF-8 literally in strings rather than escaping it if it is print
 
 ### Substrings
 
-The @code`string/slice` function is used to get substrings from a string. Negative
-integers can be used to index from the end of the string.
+The @code`string/slice` function is used to get substrings from a string.
+Negative integers can be used to index from the end of the string.
 
 @codeblock[janet]```
 (string/slice "abcdefg") # -> "abcdefg"
@@ -104,10 +108,10 @@ integers can be used to index from the end of the string.
 
 ### Finding substrings
 
-Janet has multiple functions for finding and replacing strings. The
-Janet string finding functions do not work on patterns or regular expressions;
-they only work on string literals. For more flexible searching and replacing, see
-the @link[/docs/peg.html][PEG section].
+Janet has multiple functions for finding and replacing strings. The Janet string
+finding functions do not work on patterns or regular expressions; they only work
+on string literals. For more flexible searching and replacing, see the
+@link[/docs/peg.html][PEG section].
 
 @codeblock[janet]```
 (string/find "h" "h h h h") #-> 0
@@ -118,9 +122,9 @@ the @link[/docs/peg.html][PEG section].
 
 ### Splitting strings
 
-The @code`string/split` function can be used to split strings or buffers on a delimiting
-character. This can be used as a quick and dirty function for getting fields
-from a CSV line or words from a sentence.
+The @code`string/split` function can be used to split strings or buffers on a
+delimiting character. This can be used as a quick and dirty function for getting
+fields from a CSV line or words from a sentence.
 
 @codeblock[janet]```
 (string/split "," "abc,def,ghi") #-> @["abc" "def" "ghi"]
@@ -129,27 +133,27 @@ from a CSV line or words from a sentence.
 
 ### Concatenating strings
 
-There are many ways to concatenate strings. The first, most common
-way is the @code`string` function, which takes any number of arguments and
-creates a string that is the concatenation of all of the arguments.
+There are many ways to concatenate strings. The first, most common way is the
+@code`string` function, which takes any number of arguments and creates a string
+that is the concatenation of all of the arguments.
 
 @codeblock[janet]```
 (string "abc" 123 "def") # -> "abc123def"
 ```
 
-The second way is the @code`string/join` function, which takes an array
-or tuple of strings and joins them together. @code`string/join` can also
-take an optional separator string which is inserted between items in
-the array. All items in the array or tuple must be byte sequences.
+The second way is the @code`string/join` function, which takes an array or tuple
+of strings and joins them together. @code`string/join` can also take an optional
+separator string which is inserted between items in the array. All items in the
+array or tuple must be byte sequences.
 
 @codeblock[janet]```
 (string/join @["abc" "123" "def"]) #-> "abc123def"
 (string/join @["abc" "123" "def"] ",") # -> "abc,123,def"
 ```
 
-This has the advantage over the @code`string` function that one can
-specify a separator. Otherwise, the behavior can be easily emulated
-using the @code`splice` special form.
+This has the advantage over the @code`string` function that one can specify a
+separator. Otherwise, the behavior can be easily emulated using the
+@code`splice` special form.
 
 @codeblock[janet]```
 (= (string ;@["a" "b" "c"])
@@ -158,10 +162,10 @@ using the @code`splice` special form.
 
 ### Upper and lower case
 
-The string library also provides facilities for converting strings to
-upper case and lower case. However, only ASCII characters will be transformed.
-The functions @code`string/ascii-upper` and @code`string/ascii-lower`
-return a new string that has all character in the appropriate case.
+The string library also provides facilities for converting strings to upper case
+and lower case. However, only ASCII characters will be transformed.  The
+functions @code`string/ascii-upper` and @code`string/ascii-lower` return a new
+string that has all character in the appropriate case.
 
 @codeblock[janet]```
 (string/ascii-upper "aBcdef--*") #-> "ABCDEF--*"

--- a/content/docs/syntax.mdz
+++ b/content/docs/syntax.mdz
@@ -3,28 +3,27 @@
  :order 1}
 ---
 
-
 A Janet program begins life as a text file, just a sequence of bytes like any
 other file on the system. Janet source files should be UTF-8 or ASCII encoded.
 Before Janet can compile or run the program, it must transform the source code
 into a data structure. Like Lisp, Janet source code is homoiconic - code is
 represented as Janet's core data structures - thus all the facilities in the
-language for the manipulation of tuples, strings and tables can easily be used for
-manipulation of the source code as well.
+language for the manipulation of tuples, strings and tables can easily be used
+for manipulation of the source code as well.
 
 However, before Janet code transforms into a data structure, it must be read, or
-parsed, by the Janet parser. The parser, often called the reader in Lisp,
-is a machine that takes in plain text and outputs data structures which can be
-used by both the compiler and macros. In Janet, it is a parser rather than a
-reader because there is no code execution at reading time. This approach is
-safer and more straightforward, and makes syntax higlighting, formatting, and other
-syntax analysis simpler. While a parser is not extensible, in Janet the
-philosophy is to extend the language via macros rather than reader macros.
+parsed, by the Janet parser. The parser, often called the reader in Lisp, is a
+machine that takes in plain text and outputs data structures which can be used
+by both the compiler and macros. In Janet, it is a parser rather than a reader
+because there is no code execution at reading time. This approach is safer and
+more straightforward, and makes syntax higlighting, formatting, and other syntax
+analysis simpler. While a parser is not extensible, in Janet the philosophy is
+to extend the language via macros rather than reader macros.
 
 ## @code`nil`, @code`true` and @code`false`
 
-The values @code`nil`, @code`true` and @code`false` are all literals that can be entered as such
-in the parser.
+The values @code`nil`, @code`true` and @code`false` are all literals that can be
+entered as such in the parser.
 
 @codeblock[janet]```
 nil
@@ -41,11 +40,11 @@ starting with a digit or a colon. They can also contain the characters @code`!`,
 @code`?`, @code`\`, @code`,` as well as any Unicode codepoint not in the ASCII
 range.
 
-By convention, most symbols should be all lower case and use dashes to connect words
-(sometimes called kebab case).
+By convention, most symbols should be all lower case and use dashes to connect
+words (sometimes called kebab case).
 
-Symbols that come from another module will typically contain a slash that separates
-the name of the module from the name of the definition in the module.
+Symbols that come from another module will typically contain a slash that
+separates the name of the module from the name of the definition in the module.
 
 @codeblock[janet]```
 symbol
@@ -60,10 +59,10 @@ my-module/my-fuction
 
 ## Keywords
 
-Janet keywords are like symbols that begin with the character @code`:`. However, they
-are used differently and treated by the compiler as a constant rather than a name for
-something. Keywords are used mostly for keys in tables and structs, or pieces of syntax
-in macros.
+Janet keywords are like symbols that begin with the character @code`:`. However,
+they are used differently and treated by the compiler as a constant rather than
+a name for something. Keywords are used mostly for keys in tables and structs,
+or pieces of syntax in macros.
 
 @codeblock[janet]```
 :keyword
@@ -76,14 +75,15 @@ in macros.
 
 ## Numbers
 
-Janet numbers are represented by IEEE 754 floating point numbers.
-The syntax is similar to that of many other languages
-as well. Numbers can be written in base 10, with
-underscores used to separate digits into groups. A decimal point can be used for floating
-point numbers. Numbers can also be written in other bases by prefixing the number with the desired
-base and the character @code`r`. For example, 16 can be written as @code`16`, @code`1_6`, @code`16r10`, @code`4r100`, or @code`0x10`. The
-@code`0x` prefix can be used for hexadecimal as it is so common. The radix must be written in base 10, and
-can be any integer from 2 to 36. For any radix above 10, use the letters as digits (not case sensitive).
+Janet numbers are represented by IEEE 754 floating point numbers.  The syntax is
+similar to that of many other languages as well. Numbers can be written in base
+10, with underscores used to separate digits into groups. A decimal point can be
+used for floating point numbers. Numbers can also be written in other bases by
+prefixing the number with the desired base and the character @code`r`. For
+example, 16 can be written as @code`16`, @code`1_6`, @code`16r10`, @code`4r100`,
+or @code`0x10`. The @code`0x` prefix can be used for hexadecimal as it is so
+common. The radix must be written in base 10, and can be any integer from 2 to
+36. For any radix above 10, use the letters as digits (not case sensitive).
 
 @codeblock[janet]```
 0
@@ -101,11 +101,11 @@ can be any integer from 2 to 36. For any radix above 10, use the letters as digi
 ## Strings
 
 Strings in Janet are surrounded by double quotes. Strings are 8-bit clean,
-meaning they can contain any arbitrary sequence of bytes, including embedded
-0s. To insert a double quote into a string itself, escape
-the double quote with a backslash. For unprintable characters, you can either use
-one of a few common escapes, use the @code`\xHH` escape to escape a single byte in
-hexidecimal. The supported escapes are:
+meaning they can contain any arbitrary sequence of bytes, including embedded 0s.
+To insert a double quote into a string itself, escape the double quote with a
+backslash. For unprintable characters, you can either use one of a few common
+escapes, use the @code`\xHH` escape to escape a single byte in hexidecimal. The
+supported escapes are:
 
 @ul{@li{@code`\xHH` Escape a single arbitrary byte in hexidecimal.}
     @li{@code`\n` Newline (ASCII 10)}
@@ -118,18 +118,18 @@ hexidecimal. The supported escapes are:
     @li{@code`\"` Double Quote (ASCII 34)}
     @li{@code`\\` Backslash (ASCII 92)}}
 
-Strings can also contain literal newline characters that will be ignored.
-This lets one define a multiline string that does not contain newline characters.
+Strings can also contain literal newline characters that will be ignored.  This
+lets one define a multiline string that does not contain newline characters.
 
 ### Long strings
 
 An alternative way of representing strings in Janet is the long string, or the
-backquote-delimited string. A string can also be defined to start with a certain number of
-backquotes, and will end the same number of backquotes. Long strings
+backquote-delimited string. A string can also be defined to start with a certain
+number of backquotes, and will end the same number of backquotes. Long strings
 do not contain escape sequences; all bytes will be parsed literally until the
-ending delimiter is found. This is useful
-for defining multi-line strings with literal newline characters, unprintable
-characters, or strings that would otherwise require many escape sequences.
+ending delimiter is found. This is useful for defining multi-line strings with
+literal newline characters, unprintable characters, or strings that would
+otherwise require many escape sequences.
 
 @codeblock[janet]```
 "This is a string."
@@ -152,10 +152,10 @@ a string.
 
 ## Buffers
 
-Buffers are similar to strings except they are mutable data structures. Strings in Janet
-cannot be mutated after being created, whereas a buffer can be changed after creation.
-The syntax for a buffer is the same as that for a string or long string, but
-the buffer must be prefixed with the @code`@` character.
+Buffers are similar to strings except they are mutable data structures. Strings
+in Janet cannot be mutated after being created, whereas a buffer can be changed
+after creation.  The syntax for a buffer is the same as that for a string or
+long string, but the buffer must be prefixed with the @code`@` character.
 
 @codeblock[janet]```
 @""
@@ -168,24 +168,25 @@ Yet another buffer
 
 ## Tuples
 
-Tuples are a sequence of whitespace separated values surrounded by either parentheses
-or brackets. The parser considers any of the characters ASCII 32, @code`\0`,
-@code`\f`, @code`\n`, @code`\r` or @code`\t` to be whitespace.
+Tuples are a sequence of whitespace separated values surrounded by either
+parentheses or brackets. The parser considers any of the characters ASCII 32,
+@code`\0`, @code`\f`, @code`\n`, @code`\r` or @code`\t` to be whitespace.
 
 @codeblock[janet]```
 (do 1 2 3)
 [do 1 2 3]
 ```
 
-Square brackets indicate that a tuple will be used as a tuple literal rather than
-a function call, macro call, or special form. The parser will set a flag on a tuple
-if it has square brackets to let the compiler know to compile the tuple into a
-constructor. The programmer can check if a tuple has brackets via the
+Square brackets indicate that a tuple will be used as a tuple literal rather
+than a function call, macro call, or special form. The parser will set a flag on
+a tuple if it has square brackets to let the compiler know to compile the tuple
+into a constructor. The programmer can check if a tuple has brackets via the
 @code`tuple/type` function.
 
 ## Arrays
 
-Arrays are the same as tuples, but have a leading @code`@` to indicate mutability.
+Arrays are the same as tuples, but have a leading @code`@` to indicate
+mutability.
 
 @codeblock[janet]```
 @(:one :two :three)
@@ -195,10 +196,11 @@ Arrays are the same as tuples, but have a leading @code`@` to indicate mutabilit
 ## Structs
 
 Structs are represented by a sequence of whitespace-delimited key-value pairs
-surrounded by curly braces. The sequence is defined as key1, value1, key2, value2, etc.
-There must be an even number of items between curly braces or the parser will
-signal a parse error. Any value can be a key or value. Using @code`nil` or @code`NaN` as a key, however,
-will drop that pair from the parsed struct.
+surrounded by curly braces. The sequence is defined as key1, value1, key2,
+value2, etc.  There must be an even number of items between curly braces or the
+parser will signal a parse error. Any value can be a key or value. Using
+@code`nil` or @code`NaN` as a key, however, will drop that pair from the parsed
+struct.
 
 @codeblock[janet]```
 {}
@@ -210,8 +212,8 @@ will drop that pair from the parsed struct.
 
 ## Tables
 
-Tables have the same syntax as structs, except they have the @code`@` prefix to indicate
-that they are mutable.
+Tables have the same syntax as structs, except they have the @code`@` prefix to
+indicate that they are mutable.
 
 @codeblock[janet]```
 @{}
@@ -228,9 +230,9 @@ There are no multiline comments.
 
 ## Shorthand
 
-Often called reader macros in other programming languages, Janet provides several shorthand
-notations for some forms. In Janet, this syntax is referred to as prefix forms and they are not
-extensible.
+Often called reader macros in other programming languages, Janet provides
+several shorthand notations for some forms. In Janet, this syntax is referred to
+as prefix forms and they are not extensible.
 
 ### @code`'x`
 
@@ -252,20 +254,23 @@ Shorthand for @code`(unquote x)`
 
 Shorthand for @code`(short-fn (body $))`
 
-These shorthand notations can be combined in any order, allowing
-forms like @code`''x` \ (@code`(quote (quote x))`), or @code`,;x` \ (@code`(unquote (splice x))`).
+These shorthand notations can be combined in any order, allowing forms like
+@code`''x` \ (@code`(quote (quote x))`), or @code`,;x` \ 
+(@code`(unquote (splice x))`).
 
 ## Syntax Highlighting
 
-For syntax highlighting, there is some preliminary Vim syntax highlighting in @link[https://github.com/janet-lang/janet.vim][janet.vim].
-Generic lisp syntax highlighting should, however, provide good results. One can also generate a @code`janet.tmLanguage`
-file for other programs with @code`make grammar` from the Janet source code.
+For syntax highlighting, there is some preliminary Vim syntax highlighting in
+@link[https://github.com/janet-lang/janet.vim][janet.vim].  Generic lisp syntax
+highlighting should, however, provide good results. One can also generate a
+@code`janet.tmLanguage` file for other programs with @code`make grammar` from
+the Janet source code.
 
 ## Grammar
 
 For anyone looking for a more succinct description of the grammar, a PEG grammar
-for recognizing Janet source code is below. The PEG syntax is itself similar to EBNF.
-More info on the PEG syntax can be found in the @link[/docs/peg.html][PEG section].
+for recognizing Janet source code is below. The PEG syntax is itself similar to
+EBNF.  More info on the PEG syntax can be found in the @link[/docs/peg.html][PEG section].
 
 @codeblock[janet]```
 (def grammar

--- a/content/docs/syntax.mdz
+++ b/content/docs/syntax.mdz
@@ -9,10 +9,10 @@ other file on the system. Janet source files should be UTF-8 or ASCII encoded.
 Before Janet can compile or run the program, it must transform the source code
 into a data structure. Like Lisp, Janet source code is homoiconic - code is
 represented as Janet's core data structures - thus all the facilities in the
-language for manipulation of tuples, strings and tables can easily be used for
+language for the manipulation of tuples, strings and tables can easily be used for
 manipulation of the source code as well.
 
-However, before Janet code transforms to a data structure, it must be read, or
+However, before Janet code transforms into a data structure, it must be read, or
 parsed, by the Janet parser. The parser, often called the reader in Lisp,
 is a machine that takes in plain text and outputs data structures which can be
 used by both the compiler and macros. In Janet, it is a parser rather than a
@@ -21,9 +21,9 @@ safer and more straightforward, and makes syntax higlighting, formatting, and ot
 syntax analysis simpler. While a parser is not extensible, in Janet the
 philosophy is to extend the language via macros rather than reader macros.
 
-## Nil, True and False
+## @code`nil`, @code`true` and @code`false`
 
-Nil, true and false are all literals that can be entered as such
+The values @code`nil`, @code`true` and @code`false` are all literals that can be entered as such
 in the parser.
 
 @codeblock[janet]```
@@ -34,16 +34,18 @@ false
 
 ## Symbols
 
-Janet symbols are represented as a sequence of alphanumeric characters
-not starting with a digit or a colon. They can also contain the characters
-!, \@, $, %, ^, &, *, -, _, +, =, |, ~, :, <, >, ., ?, \, , as
-well as any Unicode codepoint not in the ASCII range.
+Janet symbols are represented as a sequence of alphanumeric characters not
+starting with a digit or a colon. They can also contain the characters @code`!`,
+@code`\@`, @code`$`, @code`%`, @code`^`, @code`&`, @code`*`, @code`-`,@code` _`,
+@code`+`, @code`=`, @code`|`, @code`~`, @code`:`, @code`<`, @code`>`, @code`.`,
+@code`?`, @code`\`, @code`,` as well as any Unicode codepoint not in the ASCII
+range.
 
 By convention, most symbols should be all lower case and use dashes to connect words
 (sometimes called kebab case).
 
-Symbols that come from another module often contain a forward slash that separates
-the name of the module from the name of the definition in the module
+Symbols that come from another module will typically contain a slash that separates
+the name of the module from the name of the definition in the module.
 
 @codeblock[janet]```
 symbol
@@ -58,7 +60,7 @@ my-module/my-fuction
 
 ## Keywords
 
-Janet keywords are like symbols that begin with the character :. However, they
+Janet keywords are like symbols that begin with the character @code`:`. However, they
 are used differently and treated by the compiler as a constant rather than a name for
 something. Keywords are used mostly for keys in tables and structs, or pieces of syntax
 in macros.
@@ -74,13 +76,13 @@ in macros.
 
 ## Numbers
 
-Janet numbers are represented by IEEE-754 floating point numbers.
+Janet numbers are represented by IEEE 754 floating point numbers.
 The syntax is similar to that of many other languages
 as well. Numbers can be written in base 10, with
 underscores used to separate digits into groups. A decimal point can be used for floating
 point numbers. Numbers can also be written in other bases by prefixing the number with the desired
-base and the character 'r'. For example, 16 can be written as @code`16`, @code`1_6`, @code`16r10`, @code`4r100`, or @code`0x10`. The
-@code`0x` prefix can be used for hexadecimal as it is so common. The radix must be themselves written in base 10, and
+base and the character @code`r`. For example, 16 can be written as @code`16`, @code`1_6`, @code`16r10`, @code`4r100`, or @code`0x10`. The
+@code`0x` prefix can be used for hexadecimal as it is so common. The radix must be written in base 10, and
 can be any integer from 2 to 36. For any radix above 10, use the letters as digits (not case sensitive).
 
 @codeblock[janet]```
@@ -98,7 +100,7 @@ can be any integer from 2 to 36. For any radix above 10, use the letters as digi
 
 ## Strings
 
-Strings in janet are surrounded by double quotes. Strings are 8bit clean,
+Strings in Janet are surrounded by double quotes. Strings are 8-bit clean,
 meaning they can contain any arbitrary sequence of bytes, including embedded
 0s. To insert a double quote into a string itself, escape
 the double quote with a backslash. For unprintable characters, you can either use
@@ -119,8 +121,10 @@ hexidecimal. The supported escapes are:
 Strings can also contain literal newline characters that will be ignored.
 This lets one define a multiline string that does not contain newline characters.
 
-An alternative way of representing strings in janet is the long string, or the backquote
-delimited string. A string can also be defined to start with a certain number of
+### Long strings
+
+An alternative way of representing strings in Janet is the long string, or the
+backquote-delimited string. A string can also be defined to start with a certain number of
 backquotes, and will end the same number of backquotes. Long strings
 do not contain escape sequences; all bytes will be parsed literally until the
 ending delimiter is found. This is useful
@@ -148,10 +152,10 @@ a string.
 
 ## Buffers
 
-Buffers are similar to strings except they are mutable data structures. Strings in janet
+Buffers are similar to strings except they are mutable data structures. Strings in Janet
 cannot be mutated after being created, whereas a buffer can be changed after creation.
 The syntax for a buffer is the same as that for a string or long string, but
-the buffer must be prefixed with the '\@' character.
+the buffer must be prefixed with the @code`@` character.
 
 @codeblock[janet]```
 @""
@@ -164,9 +168,9 @@ Yet another buffer
 
 ## Tuples
 
-Tuples are a sequence of white space separated values surrounded by either parentheses
-or brackets. The parser considers any of the characters ASCII 32, \\0, \\f, \\n, \\r or \\t
-to be white-space.
+Tuples are a sequence of whitespace separated values surrounded by either parentheses
+or brackets. The parser considers any of the characters ASCII 32, @code`\0`,
+@code`\f`, @code`\n`, @code`\r` or @code`\t` to be whitespace.
 
 @codeblock[janet]```
 (do 1 2 3)
@@ -181,7 +185,7 @@ constructor. The programmer can check if a tuple has brackets via the
 
 ## Arrays
 
-Arrays are the same as tuples, but have a leading \@ to indicate mutability.
+Arrays are the same as tuples, but have a leading @code`@` to indicate mutability.
 
 @codeblock[janet]```
 @(:one :two :three)
@@ -190,12 +194,11 @@ Arrays are the same as tuples, but have a leading \@ to indicate mutability.
 
 ## Structs
 
-Structs are represented by a sequence of white-space delimited key value pairs
+Structs are represented by a sequence of whitespace-delimited key-value pairs
 surrounded by curly braces. The sequence is defined as key1, value1, key2, value2, etc.
 There must be an even number of items between curly braces or the parser will
-signal a parse error. Any value can be a key or value. Using nil or NaN as a key, however,
-will drop that pair from the parsed struct. Using nil as value will drop that
-pair from the parsed struct
+signal a parse error. Any value can be a key or value. Using @code`nil` or @code`NaN` as a key, however,
+will drop that pair from the parsed struct.
 
 @codeblock[janet]```
 {}
@@ -204,9 +207,10 @@ pair from the parsed struct
 {@[] @[]}
 {1 2 3 4 5 6}
 ```
+
 ## Tables
 
-Tables have the same syntax as structs, except they have the \@ prefix to indicate
+Tables have the same syntax as structs, except they have the @code`@` prefix to indicate
 that they are mutable.
 
 @codeblock[janet]```
@@ -219,8 +223,8 @@ that they are mutable.
 
 ## Comments
 
-Comments begin with a # character and continue until the end of the line.
-There are no multi-line comments.
+Comments begin with a @code`#` character and continue until the end of the line.
+There are no multiline comments.
 
 ## Shorthand
 
@@ -253,15 +257,15 @@ forms like @code`''x` \ (@code`(quote (quote x))`), or @code`,;x` \ (@code`(unqu
 
 ## Syntax Highlighting
 
-For syntax highlighting, there is some preliminary vim syntax highlighting in @link[https://github.com/janet-lang/janet.vim][janet.vim].
-Generic lisp syntax highlighting should, however, provide good results. One can also generate a janet.tmLanguage
+For syntax highlighting, there is some preliminary Vim syntax highlighting in @link[https://github.com/janet-lang/janet.vim][janet.vim].
+Generic lisp syntax highlighting should, however, provide good results. One can also generate a @code`janet.tmLanguage`
 file for other programs with @code`make grammar` from the Janet source code.
 
 ## Grammar
 
 For anyone looking for a more succinct description of the grammar, a PEG grammar
 for recognizing Janet source code is below. The PEG syntax is itself similar to EBNF.
-More info on the PEG syntax can be found in @link[/docs/peg.html][the documentation for the peg module].
+More info on the PEG syntax can be found in the @link[/docs/peg.html][PEG section].
 
 @codeblock[janet]```
 (def grammar

--- a/content/docs/threads.mdz
+++ b/content/docs/threads.mdz
@@ -5,11 +5,11 @@
 
 Starting in version 1.6.0, Janet has the ability to do true, non-cooperative multithreading with the @code`thread/`
 functions. Janet threads correspond to native threads on the host operating system, which may be either pthreads on
-posix systems or Windows threads. Each thread has its own Janet heap, which means threads behave more like processes
+POSIX systems or Windows threads. Each thread has its own Janet heap, which means threads behave more like processes
 that communicate by message passing. However, this does not prevent native code from sharing memory across these threads.
 Without native extensions, however, the only way for two Janet threads to communicate directly is through message passing.
 
-## Creating Threads
+## Creating threads
 
 Use @code`(thread/new func &opt capacity)` to create a new thread. This thread will start and wait for a message containing a function
 that it will run as the main body. This function must also be able to take 1 parameter, the parent thread.
@@ -26,7 +26,7 @@ will have an initial capacity of 10.
 (def thread (thread/new worker 32))
 ```
 
-## Sending and Receiving Messages
+## Sending and receiving messages
 
 Threads in Janet do not share a memory heap and must communicate via message passing. Use @code`thread/send`
 to send a message to a thread, and @code`thread/receive` to get messages sent to the current thread.
@@ -43,7 +43,7 @@ to send a message to a thread, and @code`thread/receive` to get messages sent to
 (:send thread "Hello!")
 ```
 
-## Limitations of Messages
+## Limitations of messages
 
 Since threads do not share Janet heaps, all values sent as messages are first marshalled to a byte sequence by the sending thread, and then
 unmarshalled by the receiving thread. For marshalling and unmarshalling, threads use the two tables @code`make-image-dict` and
@@ -81,14 +81,14 @@ its own copy of the file handle.
 (thread/new worker)
 ```
 
-This limitation has been removed for some values (C Functions and raw pointers) in
+This limitation has been removed for some values (C functions and raw pointers) in
 version 1.9.0, to make use of threads with native modules more seamless, although certain abstract
 types like open files can still not be sent to threads via @code`thread/send` or @code`thread/new`.
 
-## Blocking and Non-blocking Sends and Receives
+## Blocking and non-blocking sends and receives
 
 All sends and receives can be blocking or non-blocking by providing an optional timeout value. A timeout
-of 0 makes @code`(thread/send to msg &opt timeout)` and @code`(thread/receive &opt timeout)` non-blocking, while a positive timeout value
+of @code`0` makes @code`(thread/send to msg &opt timeout)` and @code`(thread/receive &opt timeout)` non-blocking, while a positive timeout value
 indicates a blocking send or receive that will resume the current thread by throwing an error after
 timeout seconds. Timeouts are limited to 30 days, with the exception that using @code`math/inf` for a timeout means that a timeout will never occur.
 

--- a/content/docs/threads.mdz
+++ b/content/docs/threads.mdz
@@ -3,19 +3,24 @@
  :order 18}
 ---
 
-Starting in version 1.6.0, Janet has the ability to do true, non-cooperative multithreading with the @code`thread/`
-functions. Janet threads correspond to native threads on the host operating system, which may be either pthreads on
-POSIX systems or Windows threads. Each thread has its own Janet heap, which means threads behave more like processes
-that communicate by message passing. However, this does not prevent native code from sharing memory across these threads.
-Without native extensions, however, the only way for two Janet threads to communicate directly is through message passing.
+Starting in version 1.6.0, Janet has the ability to do true, non-cooperative
+multithreading with the @code`thread/` functions. Janet threads correspond to
+native threads on the host operating system, which may be either pthreads on
+POSIX systems or Windows threads. Each thread has its own Janet heap, which
+means threads behave more like processes that communicate by message passing.
+However, this does not prevent native code from sharing memory across these
+threads.  Without native extensions, however, the only way for two Janet threads
+to communicate directly is through message passing.
 
 ## Creating threads
 
-Use @code`(thread/new func &opt capacity)` to create a new thread. This thread will start and wait for a message containing a function
-that it will run as the main body. This function must also be able to take 1 parameter, the parent thread.
-Each thread has its own mailbox, which can asynchronously receive messages. These messages are added to a queue, which has
-a configurable maximum capacity according to the second optional argument passed to @code`thread/new`. If unspecified, the mailbox
-will have an initial capacity of 10.
+Use @code`(thread/new func &opt capacity)` to create a new thread. This thread
+will start and wait for a message containing a function that it will run as the
+main body. This function must also be able to take 1 parameter, the parent
+thread.  Each thread has its own mailbox, which can asynchronously receive
+messages. These messages are added to a queue, which has a configurable maximum
+capacity according to the second optional argument passed to @code`thread/new`.
+If unspecified, the mailbox will have an initial capacity of 10.
 
 @codeblock[janet]```
 (defn worker
@@ -28,8 +33,9 @@ will have an initial capacity of 10.
 
 ## Sending and receiving messages
 
-Threads in Janet do not share a memory heap and must communicate via message passing. Use @code`thread/send`
-to send a message to a thread, and @code`thread/receive` to get messages sent to the current thread.
+Threads in Janet do not share a memory heap and must communicate via message
+passing. Use @code`thread/send` to send a message to a thread, and
+@code`thread/receive` to get messages sent to the current thread.
 
 @codeblock[janet]```
 (defn worker
@@ -45,16 +51,20 @@ to send a message to a thread, and @code`thread/receive` to get messages sent to
 
 ## Limitations of messages
 
-Since threads do not share Janet heaps, all values sent as messages are first marshalled to a byte sequence by the sending thread, and then
-unmarshalled by the receiving thread. For marshalling and unmarshalling, threads use the two tables @code`make-image-dict` and
-@code`load-image-dict`. This means you can send over core bindings, even if the underlying value cannot be marshalled.
-Semantically, messages sent with @code`(thread/send to msg)` are first converted to a buffer
-via @code`(marshal msg make-image-dict mailbox-buf)`,
-and then unmarshalled by the receiving thread via @code`(unmarshal mailbox-buf load-image-dict)`.
+Since threads do not share Janet heaps, all values sent as messages are first
+marshalled to a byte sequence by the sending thread, and then unmarshalled by
+the receiving thread. For marshalling and unmarshalling, threads use the two
+tables @code`make-image-dict` and @code`load-image-dict`. This means you can
+send over core bindings, even if the underlying value cannot be marshalled.
+Semantically, messages sent with @code`(thread/send to msg)` are first converted
+to a buffer via @code`(marshal msg make-image-dict mailbox-buf)`, and then
+unmarshalled by the receiving thread via @code`(unmarshal mailbox-buf
+load-image-dict)`.
 
-Values that cannot be marshalled, including thread values, cannot be sent as messages to other threads, or even
-as part of a message to another thread. For example, the following will not work because open file handles
-cannot be marshalled.
+Values that cannot be marshalled, including thread values, cannot be sent as
+messages to other threads, or even as part of a message to another thread. For
+example, the following will not work because open file handles cannot be
+marshalled.
 
 @codeblock[janet]```
 (def file (file/open "myfile.txt" :w))
@@ -67,8 +77,8 @@ cannot be marshalled.
 (thread/new worker)
 ```
 
-The fix here is to move the file creation inside the worker function, since every worker thread is going to have
-its own copy of the file handle.
+The fix here is to move the file creation inside the worker function, since
+every worker thread is going to have its own copy of the file handle.
 
 @codeblock[janet]```
 (defn worker
@@ -81,16 +91,21 @@ its own copy of the file handle.
 (thread/new worker)
 ```
 
-This limitation has been removed for some values (C functions and raw pointers) in
-version 1.9.0, to make use of threads with native modules more seamless, although certain abstract
-types like open files can still not be sent to threads via @code`thread/send` or @code`thread/new`.
+This limitation has been removed for some values (C functions and raw pointers)
+in version 1.9.0, to make use of threads with native modules more seamless,
+although certain abstract types like open files can still not be sent to threads
+via @code`thread/send` or @code`thread/new`.
 
 ## Blocking and non-blocking sends and receives
 
-All sends and receives can be blocking or non-blocking by providing an optional timeout value. A timeout
-of @code`0` makes @code`(thread/send to msg &opt timeout)` and @code`(thread/receive &opt timeout)` non-blocking, while a positive timeout value
-indicates a blocking send or receive that will resume the current thread by throwing an error after
-timeout seconds. Timeouts are limited to 30 days, with the exception that using @code`math/inf` for a timeout means that a timeout will never occur.
+All sends and receives can be blocking or non-blocking by providing an optional
+timeout value. A timeout of @code`0` makes
+@code`(thread/send to msg &opt timeout)` and
+@code`(thread/receive &opt timeout)` non-blocking, while a positive timeout
+value indicates a blocking send or receive that will resume the current thread
+by throwing an error after timeout seconds. Timeouts are limited to 30 days,
+with exception the using @code`math/inf` for a timeout means that a timeout
+will never occur.
 
 @codeblock[janet]```
 (defn worker

--- a/content/index.mdz
+++ b/content/index.mdz
@@ -8,7 +8,7 @@
 
 Feel free to ask questions and join discussion on the @link[https://gitter.im/janet-language/community]{Janet Gitter Channel}.
 Alternatively, check out @link[https://webchat.freenode.net/]{the #janet channel on Freenode}.
-For help, you can also checkout @link[https://janetdocs.com]{Janet Docs} for the Janet documentation with user provided examples.
+For help, you can also checkout @link[https://janetdocs.com]{Janet Docs} for Janet documentation with user-provided examples.
 
 ## Use Cases
 
@@ -29,7 +29,7 @@ are fairly straightforward. Janet can be easily ported to new platforms.
     @li{Mutable and immutable strings (buffer/string)}
     @li{Macros}
     @li{Byte code interpreter with an assembly interface, as well as bytecode verification}
-    @li{Tailcall Optimization}
+    @li{Tail call optimization}
     @li{Direct interop with C via abstract types and C functions}
     @li{Dynamically load C libraries}
     @li{Functional and imperative standard library}
@@ -56,7 +56,7 @@ are fairly straightforward. Janet can be easily ported to new platforms.
 
 ## Usage
 
-A REPL is launched when the binary is invoked with no arguments. Pass the -h flag
+A REPL is launched when the @code`janet` binary is invoked with no arguments. Pass the @code`-h` flag
 to display the usage information. Individual scripts can be run with @code`janet myscript.janet`
 
 If you are looking to explore, you can print a list of all available macros, functions, and constants


### PR DESCRIPTION
This PR really consists of two parts.

First, I have gone through each of the pages in the docs (excluding API pages) and tried to make the style consistent. This means using capitalisation and HTML `code` spans consistently and cleaning up little typos here and there. This comprises all but the last commit in this branch.

Second, I have gone through each of the same pages and wrapped the text consistently at 80 characters. I realise this is a rather personal thing and there may be reasons to prefer a different level so I made all these changes as a single commit so that they could be easily reverted.

I hope this is helpful but if there are any changes you would like me to make, please let me know.