### PR TITLE
Tweaks to janet peg sample

### DIFF
--- a/content/docs/syntax.mdz
+++ b/content/docs/syntax.mdz
@@ -283,11 +283,13 @@ EBNF.  More info on the PEG syntax can be found in the @link[/docs/peg.html][PEG
     :hex (range "09" "af" "AF")
     :escape (* "\\" (+ (set "ntrzfev0\"\\")
                        (* "x" :hex :hex)
-                       (error (constant "bad hex escape"))))
+                       (* "u" [4 :hex])
+                       (* "U" [6 :hex])
+                       (error (constant "bad escape"))))
     :comment (* "#" (any (if-not (+ "\n" -1) 1)))
     :symbol :token
     :keyword (* ":" (any :symchars))
-    :constant (+ "true" "false" "nil")
+    :constant (* (+ "true" "false" "nil") (not :symchars))
     :bytes (* "\"" (any (+ :escape (if-not "\"" 1))) "\"")
     :string :bytes
     :buffer (* "@" :bytes)


### PR DESCRIPTION
This PR includes a couple of tweaks to the janet peg sample at: https://janet-lang.org/docs/peg.html

1) The first has to do with additional escapes for strings (i.e. `\u....` and `\U......`).  For reference, spork's `fmt.janet` currently has: https://github.com/janet-lang/spork/blob/2e227d4ec8492ee3b51fa7c591e83f126e9e1ad8/spork/fmt.janet#L22-L23

The included change for this just uses newer notation.

2) The other has to do with recognition of things that initially overlap with `:constant` (i.e. `false`, `nil`, `true`).  As an example, `nila` appears to be recognized as two things `nil` and `a`.  Presumably, one would prefer `nila` to be recognized as a single symbol.

May be there's a better way to do this than what's in this PR.

Any ideas?

