### PR TITLE
Prune legal symbol character list

### DIFF
--- a/content/docs/syntax.mdz
+++ b/content/docs/syntax.mdz
@@ -35,9 +35,9 @@ false
 
 Janet symbols are represented as a sequence of alphanumeric characters not
 starting with a digit or a colon. They can also contain the characters @code`!`,
-@code`\@`, @code`$`, @code`%`, @code`^`, @code`&`, @code`*`, @code`-`,@code` _`,
-@code`+`, @code`=`, @code`|`, @code`~`, @code`:`, @code`<`, @code`>`, @code`.`,
-@code`?`, @code`\`, @code`,` as well as any Unicode codepoint not in the ASCII
+@code`@`, @code`$`, @code`%`, @code`^`, @code`&`, @code`*`, @code`-`, @code`_`,
+@code`+`, @code`=`, @code`:`, @code`<`, @code`>`, @code`.`, @code`?`
+as well as any Unicode codepoint not in the ASCII
 range.
 
 By convention, most symbols should be all lower case and use dashes to connect


### PR DESCRIPTION
This PR attempts to update the list of legal characters for use in symbols.

The characters removed from the list include:

* `|`
* `~`
* `\`
* `,`

IIUC, these are all reserved for other purposes now (except for the backslash which appears reserved for the future) at least in typical use -- though it does seem possible to create symbols with them using for example:
```
(symbol "~a")
```

I thought it might be preferable to not list them in the doc page, at least not without further clarification or warning.

The PR also tweaked:

```
@code`\@` -> @code`@`
@code` _` -> @code`_`
```

The former is a deletion of a backslash and the latter is a deletion of space