### PR TITLE
Cover both `try` and `protect` in error section

### DIFF
--- a/content/docs/fibers/error_handling.mdz
+++ b/content/docs/fibers/error_handling.mdz
@@ -32,8 +32,14 @@ from the last call to @code`resume`.
  (print "value returned: " res))
 ```
 
-Janet also provides a simple macro @code`try` to make this a bit easier in the
-common case.
+## Two error-handling forms built on fibers
+
+### @code`try`
+
+Janet provides a simple macro @code`try` to make error-handling a bit
+easier in the common case. @code`try` performs the function of a
+traditional try/catch block; it will execute its body and, if any
+error is raised, pattern match against the error in its second clause.
 
 @codeblock[janet]```
 (try
@@ -42,4 +48,17 @@ common case.
    (error "oops")
    (print "will never get here"))
  ([err] (print "caught error: " err)))
+```
+
+### @code`protect`
+
+Janet also provides the @code`protect` macro for a slightly different
+flavor of error-handling, converting caught errors into further
+expressions.
+
+@codeblock[janet]```
+(protect
+  (if (> (math/random) 0.42)
+    (error "Good luck")
+    "Bad luck"))
 ```

--- a/content/docs/fibers/error_handling.mdz
+++ b/content/docs/fibers/error_handling.mdz
@@ -39,7 +39,8 @@ from the last call to @code`resume`.
 Janet provides a simple macro @code`try` to make error-handling a bit
 easier in the common case. @code`try` performs the function of a
 traditional try/catch block; it will execute its body and, if any
-error is raised, pattern match against the error in its second clause.
+error is raised, optionally bind the error and the raising fiber in
+its second clause.
 
 @codeblock[janet]```
 (try


### PR DESCRIPTION
Adds a section on the error handling page about `protect`. `protect` and `try` seem to be equally "first-class" in terms of conveniences exposed around fiber errors, so let's document both.