### PR TITLE
Update C API docs on importing native module

### DIFF
--- a/content/capi/index.mdz
+++ b/content/capi/index.mdz
@@ -93,7 +93,7 @@ If all goes well, @code`jpm` should have built a file @code`build/mymod.so`. In 
 import your module and use it.
 
 @codeblock[janet]```
-(import build/mymod :as mymod)
+(import /build/mymod :as mymod)
 (mymod/myfun) # Prints the hello message
 ```
 


### PR DESCRIPTION
Without the leading slash it just looks in janet's sources instead of the local directory and failss