### PR TITLE
Add optional tag arg to line and column docs

### DIFF
--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -270,11 +270,11 @@ grammars simpler.
     @tr{@td{@code`($ ?tag)` }
         @td{ Alias for @code`(position ?tag)`. }}
 
-    @tr{@td{@code`(column)` }
+    @tr{@td{@code`(column ?tag)` }
         @td{ Captures the column number of the current position in the matched
         text. }}
 
-    @tr{@td{@code`(line)` }
+    @tr{@td{@code`(line ?tag)` }
         @td{ Captures the line number of the current position in the matched
         text. }}
 


### PR DESCRIPTION
This seems to work:
```
repl:1:> (peg/match ~(sequence "a" (line :a) (backref :a)) "a")
@[1 1]
```
If that's correct behavior (as well as for `column`) may be the table entries for them can be updated to have the `?tag` argument.