### PR TITLE
Use :in instead of :generate in loop example

### DIFF
--- a/examples/loop.janet
+++ b/examples/loop.janet
@@ -70,7 +70,7 @@
       (for i 0 100
         (yield i)))))
 
-(loop [x :generate f]
+(loop [x :in f]
   (print x))
 # print 0, 1, 2, ... 99
 


### PR DESCRIPTION
Update loop example to use `:in` instead of `:generate`.

Thanks to @Alligator for reporting.