### PR TITLE
Change non-existent function 'interpolate' to 'interpose' in jpm docs

### DIFF
--- a/content/docs/jpm.mdz
+++ b/content/docs/jpm.mdz
@@ -206,7 +206,7 @@ the entry point to your executable.
 
 (defn main [& args]
     # You can also get command-line arguments through (dyn :args)
-    (print "args: " ;(interpolate ", " args))
+    (print "args: " ;(interpose ", " args))
     (mylib1/do-thing)
     (mylib2/do-thing))
 ```


### PR DESCRIPTION
The `jpm` docs contain an example to print command-line arguments on a single line, separated by commas. A function `interpolate` is used which (as far as I can tell) does not exist. This PR changes the example to use `interpose` which produces the same result.