### PR TITLE
Fix absolute path in the example

### DIFF
--- a/content/capi/index.mdz
+++ b/content/capi/index.mdz
@@ -93,7 +93,7 @@ If all goes well, @code`jpm` should have built a file @code`build/mymod.so`. In 
 import your module and use it.
 
 @codeblock[janet]```
-(import /build/mymod :as mymod)
+(import ./build/mymod :as mymod)
 (mymod/myfun) # Prints the hello message
 ```
 


### PR DESCRIPTION
The code without this fix will result in an error:

```
repl:1:> (import /build/mymod :as mymod)
error: could not find module /build/mymod:
    /usr/local/lib/janet/build/mymod.jimage
    /usr/local/lib/janet/build/mymod.janet
    /usr/local/lib/janet/build/mymod/init.janet
    /usr/local/lib/janet/build/mymod.so
    /build/mymod.jimage
    /build/mymod.janet
    /build/mymod/init.janet
    /build/mymod.so
  in require-1 [boot.janet] on line 2774, column 20
  in import* [boot.janet] on line 2813, column 15
  in _thunk [repl] (tailcall) on line 1, column 1
```

Not a big deal for an experienced Linux user I guess. Never the
less, we all do copy paste and expect things to just work :-).