### PR TITLE
Fix error in memory management sample code

### DIFF
--- a/content/capi/memory-model.mdz
+++ b/content/capi/memory-model.mdz
@@ -95,7 +95,7 @@ handily be used for this.
 Better code:
 @codeblock[c]```
 Janet my_bad_cfunc(int32_t argc, Janet *argv) {
-    const Janet *argv2 = janet_tuple_n(argv, argv);
+    const Janet *argv2 = janet_tuple_n(argv, argc);
     for (int32_t i = 0; i < argc; i++) {
         JanetFunction *func = janet_getfunction(argv2, i);
         janet_call(func, 0, NULL);


### PR DESCRIPTION
The arguments to `janet_tuple_n` are `(const Janet *values, int32_t n)`, according to https://github.com/janet-lang/janet/blob/5c05dec65ae4b49e65b01f96984b81c8ca774ad4/src/core/tuple.c#L50, so the second argument to it in this sample code should be `argc` rather than `argv`.