### PR TITLE
Fixes typo on "raises and error" -> "raises an error" in event_loop

### DIFF
--- a/content/docs/event_loop.mdz
+++ b/content/docs/event_loop.mdz
@@ -99,7 +99,7 @@ With these constraints, channels are preferred for things like internal queues a
 
 Channels are based around a queue abstraction, where producer tasks will add items to the channel with @code`ev/give`, and consumer tasks will remove items from the
 channel with @code`ev/take`. If there are no items in the channel when @code`ev/take` is called, the consumer will suspend until a producer gives an item
-to the channel. Similarly, if a task gives to a full channel, it will suspend until a consumer takes an item from the queue, freeing up space for the producer 
+to the channel. Similarly, if a task gives to a full channel, it will suspend until a consumer takes an item from the queue, freeing up space for the producer
 to put an item.
 
 Internally, channels are infinitely expanding queues, so one might think that they never need to be "full", but allowing channels to fill up and suspend writers
@@ -158,7 +158,7 @@ Macros like @code`try` and @code`protect` will continue to work just as if the c
 
 ## Supervisor Channels
 
-An interesting problem with supporting multiple tasks is error handling - if a task raises and error (or any other uncaught signal), who should handle it? The programmer
+An interesting problem with supporting multiple tasks is error handling - if a task raises an error (or any other uncaught signal), who should handle it? The programmer
 often wants to know when a task fails (or finishes), and then continue with some other code. Alternatively, it might be desirable to try again a number of times before
 really giving up.
 
@@ -203,4 +203,3 @@ when it completes successfully, with the message @code`[:ok fiber]`. The most us
 These events will be tuples of 2 arguments, @code`(signal fiber)`.
 
 A task can also write custom messages to its supervisor with @code`ev/give-supervisor`.
-

--- a/static/1.13.1/docs/event_loop.html
+++ b/static/1.13.1/docs/event_loop.html
@@ -42,7 +42,7 @@
       window.addEventListener('DOMContentLoaded', addTocToggle);
     </script>
 
-    
+
 
     <div class="twocol">
       <div class="toc show-toc">
@@ -52,27 +52,27 @@
       </div>
       <div class="content-wrapper main-content">
         <h4 class="subtitle">Janet 1.13.1-392d5d5 Documentation<br>(Other Versions:
-          
+
           <a href="../../1.12.2/docs/event_loop.html">1.12.2</a>
-          
+
           <a href="../../1.11.1/docs/event_loop.html">1.11.1</a>
-          
+
           <a href="../../1.10.1/docs/event_loop.html">1.10.1</a>
-          
+
           <a href="../../1.9.1/docs/event_loop.html">1.9.1</a>
-          
+
           <a href="../../1.8.1/docs/event_loop.html">1.8.1</a>
-          
+
           <a href="../../1.7.0/docs/event_loop.html">1.7.0</a>
-          
+
           <a href="../../1.6.0/docs/event_loop.html">1.6.0</a>
-          
+
           <a href="../../1.5.1/docs/event_loop.html">1.5.1</a>
-          
+
           <a href="../../1.5.0/docs/event_loop.html">1.5.0</a>
-          
+
           <a href="../../1.4.0/docs/event_loop.html">1.4.0</a>
-          
+
           <a href="../../1.3.1/docs/event_loop.html">1.3.1</a>
           )</h4>
         <h1 class="subtitle">The Event Loop</h1>
@@ -81,7 +81,7 @@
 
           <span class="next"><a href="jpm.html"><span class="prevnext-text">jpm</span></a></span>
         </div>
-        
+
 
 <p>In addition to threads, Janet comes with another powerful concurrency model out of the box - the event loop. The event loop provides
 concurrency within a single thread by allowing cooperating fibers to yield instead of
@@ -171,7 +171,7 @@ the network.
 </h2>
 <p>Channels are based around a queue abstraction, where producer tasks will add items to the channel with <code class="mendoza-code">ev/give</code>, and consumer tasks will remove items from the
 channel with <code class="mendoza-code">ev/take</code>. If there are no items in the channel when <code class="mendoza-code">ev/take</code> is called, the consumer will suspend until a producer gives an item
-to the channel. Similarly, if a task gives to a full channel, it will suspend until a consumer takes an item from the queue, freeing up space for the producer 
+to the channel. Similarly, if a task gives to a full channel, it will suspend until a consumer takes an item from the queue, freeing up space for the producer
 to put an item.
 </p>
 <p>Internally, channels are infinitely expanding queues, so one might think that they never need to be "full", but allowing channels to fill up and suspend writers
@@ -222,7 +222,7 @@ task to be resumed but immediately error. From the point of view of the canceled
 (<span class="mdzsyn-coresym">ev/sleep</span> <span class="mdzsyn-number">2</span>)
 (<span class="mdzsyn-coresym">ev/cancel</span> <span class="mdzsyn-symbol">f</span> <span class="mdzsyn-string">"canceled"</span>)</code></pre><h2 id="Supervisor-Channels">Supervisor Channels
 </h2>
-<p>An interesting problem with supporting multiple tasks is error handling - if a task raises and error (or any other uncaught signal), who should handle it? The programmer
+<p>An interesting problem with supporting multiple tasks is error handling - if a task raises an error (or any other uncaught signal), who should handle it? The programmer
 often wants to know when a task fails (or finishes), and then continue with some other code. Alternatively, it might be desirable to try again a number of times before
 really giving up.
 </p>
@@ -272,7 +272,7 @@ These events will be tuples of 2 arguments, <code class="mendoza-code">(signal f
       </div>
     </div>
 
-    
+
 <footer>
   &copy; Calvin Rose &amp; contributors 2021
   <div class="gentag">Generated on January 19, 2021 at 00:01:56 (UTC) with Janet 1.13.1-392d5d5</div>

--- a/static/1.15.0/docs/event_loop.html
+++ b/static/1.15.0/docs/event_loop.html
@@ -42,7 +42,7 @@
       window.addEventListener('DOMContentLoaded', addTocToggle);
     </script>
 
-    
+
 
     <div class="twocol">
       <div class="toc show-toc">
@@ -52,29 +52,29 @@
       </div>
       <div class="content-wrapper main-content">
         <h4 class="subtitle">Janet 1.15.0-2795e8a Documentation<br>(Other Versions:
-          
+
           <a href="../../1.13.1/docs/event_loop.html">1.13.1</a>
-          
+
           <a href="../../1.12.2/docs/event_loop.html">1.12.2</a>
-          
+
           <a href="../../1.11.1/docs/event_loop.html">1.11.1</a>
-          
+
           <a href="../../1.10.1/docs/event_loop.html">1.10.1</a>
-          
+
           <a href="../../1.9.1/docs/event_loop.html">1.9.1</a>
-          
+
           <a href="../../1.8.1/docs/event_loop.html">1.8.1</a>
-          
+
           <a href="../../1.7.0/docs/event_loop.html">1.7.0</a>
-          
+
           <a href="../../1.6.0/docs/event_loop.html">1.6.0</a>
-          
+
           <a href="../../1.5.1/docs/event_loop.html">1.5.1</a>
-          
+
           <a href="../../1.5.0/docs/event_loop.html">1.5.0</a>
-          
+
           <a href="../../1.4.0/docs/event_loop.html">1.4.0</a>
-          
+
           <a href="../../1.3.1/docs/event_loop.html">1.3.1</a>
           )</h4>
         <h1 class="subtitle">The Event Loop</h1>
@@ -83,7 +83,7 @@
 
           <span class="next"><a href="documentation.html"><span class="prevnext-text">Documentation</span></a></span>
         </div>
-        
+
 
 <p>In addition to threads, Janet comes with another powerful concurrency model out of the box - the event loop. The event loop provides
 concurrency within a single thread by allowing cooperating fibers to yield instead of
@@ -173,7 +173,7 @@ the network.
 </h2>
 <p>Channels are based around a queue abstraction, where producer tasks will add items to the channel with <code class="mendoza-code">ev/give</code>, and consumer tasks will remove items from the
 channel with <code class="mendoza-code">ev/take</code>. If there are no items in the channel when <code class="mendoza-code">ev/take</code> is called, the consumer will suspend until a producer gives an item
-to the channel. Similarly, if a task gives to a full channel, it will suspend until a consumer takes an item from the queue, freeing up space for the producer 
+to the channel. Similarly, if a task gives to a full channel, it will suspend until a consumer takes an item from the queue, freeing up space for the producer
 to put an item.
 </p>
 <p>Internally, channels are infinitely expanding queues, so one might think that they never need to be "full", but allowing channels to fill up and suspend writers
@@ -224,7 +224,7 @@ task to be resumed but immediately error. From the point of view of the canceled
 (<span class="mdzsyn-coresym">ev/sleep</span> <span class="mdzsyn-number">2</span>)
 (<span class="mdzsyn-coresym">ev/cancel</span> <span class="mdzsyn-symbol">f</span> <span class="mdzsyn-string">"canceled"</span>)</code></pre><h2 id="Supervisor-Channels">Supervisor Channels
 </h2>
-<p>An interesting problem with supporting multiple tasks is error handling - if a task raises and error (or any other uncaught signal), who should handle it? The programmer
+<p>An interesting problem with supporting multiple tasks is error handling - if a task raises an error (or any other uncaught signal), who should handle it? The programmer
 often wants to know when a task fails (or finishes), and then continue with some other code. Alternatively, it might be desirable to try again a number of times before
 really giving up.
 </p>
@@ -274,7 +274,7 @@ These events will be tuples of 2 arguments, <code class="mendoza-code">(signal f
       </div>
     </div>
 
-    
+
 <footer>
   &copy; Calvin Rose &amp; contributors 2021
   <div class="gentag">Generated on February 10, 2021 at 02:29:55 (UTC) with Janet 1.15.0-2795e8a</div>

--- a/static/1.16.1/docs/event_loop.html
+++ b/static/1.16.1/docs/event_loop.html
@@ -42,7 +42,7 @@
       window.addEventListener('DOMContentLoaded', addTocToggle);
     </script>
 
-    
+
 
     <div class="twocol">
       <div class="toc show-toc">
@@ -52,31 +52,31 @@
       </div>
       <div class="content-wrapper main-content">
         <h4 class="subtitle">Janet 1.16.1-87f8fe1 Documentation<br>(Other Versions:
-          
+
           <a href="../../1.15.0/docs/event_loop.html">1.15.0</a>
-          
+
           <a href="../../1.13.1/docs/event_loop.html">1.13.1</a>
-          
+
           <a href="../../1.12.2/docs/event_loop.html">1.12.2</a>
-          
+
           <a href="../../1.11.1/docs/event_loop.html">1.11.1</a>
-          
+
           <a href="../../1.10.1/docs/event_loop.html">1.10.1</a>
-          
+
           <a href="../../1.9.1/docs/event_loop.html">1.9.1</a>
-          
+
           <a href="../../1.8.1/docs/event_loop.html">1.8.1</a>
-          
+
           <a href="../../1.7.0/docs/event_loop.html">1.7.0</a>
-          
+
           <a href="../../1.6.0/docs/event_loop.html">1.6.0</a>
-          
+
           <a href="../../1.5.1/docs/event_loop.html">1.5.1</a>
-          
+
           <a href="../../1.5.0/docs/event_loop.html">1.5.0</a>
-          
+
           <a href="../../1.4.0/docs/event_loop.html">1.4.0</a>
-          
+
           <a href="../../1.3.1/docs/event_loop.html">1.3.1</a>
           )</h4>
         <h1 class="subtitle">The Event Loop</h1>
@@ -85,7 +85,7 @@
 
           <span class="next"><a href="documentation.html"><span class="prevnext-text">Documentation</span></a></span>
         </div>
-        
+
 
 <p>In addition to threads, Janet comes with another powerful concurrency model out of the box - the event loop. The event loop provides
 concurrency within a single thread by allowing cooperating fibers to yield instead of
@@ -175,7 +175,7 @@ the network.
 </h2>
 <p>Channels are based around a queue abstraction, where producer tasks will add items to the channel with <code class="mendoza-code">ev/give</code>, and consumer tasks will remove items from the
 channel with <code class="mendoza-code">ev/take</code>. If there are no items in the channel when <code class="mendoza-code">ev/take</code> is called, the consumer will suspend until a producer gives an item
-to the channel. Similarly, if a task gives to a full channel, it will suspend until a consumer takes an item from the queue, freeing up space for the producer 
+to the channel. Similarly, if a task gives to a full channel, it will suspend until a consumer takes an item from the queue, freeing up space for the producer
 to put an item.
 </p>
 <p>Internally, channels are infinitely expanding queues, so one might think that they never need to be "full", but allowing channels to fill up and suspend writers
@@ -226,7 +226,7 @@ task to be resumed but immediately error. From the point of view of the canceled
 (<span class="mdzsyn-coresym">ev/sleep</span> <span class="mdzsyn-number">2</span>)
 (<span class="mdzsyn-coresym">ev/cancel</span> <span class="mdzsyn-symbol">f</span> <span class="mdzsyn-string">"canceled"</span>)</code></pre><h2 id="Supervisor-Channels">Supervisor Channels
 </h2>
-<p>An interesting problem with supporting multiple tasks is error handling - if a task raises and error (or any other uncaught signal), who should handle it? The programmer
+<p>An interesting problem with supporting multiple tasks is error handling - if a task raises an error (or any other uncaught signal), who should handle it? The programmer
 often wants to know when a task fails (or finishes), and then continue with some other code. Alternatively, it might be desirable to try again a number of times before
 really giving up.
 </p>
@@ -276,7 +276,7 @@ These events will be tuples of 2 arguments, <code class="mendoza-code">(signal f
       </div>
     </div>
 
-    
+
 <footer>
   &copy; Calvin Rose &amp; contributors 2021
   <div class="gentag">Generated on June 19, 2021 at 00:34:00 (UTC) with Janet 1.16.1-87f8fe1</div>

--- a/static/1.17.1/docs/event_loop.html
+++ b/static/1.17.1/docs/event_loop.html
@@ -42,7 +42,7 @@
       window.addEventListener('DOMContentLoaded', addTocToggle);
     </script>
 
-    
+
 
     <div class="twocol">
       <div class="toc show-toc">
@@ -52,33 +52,33 @@
       </div>
       <div class="content-wrapper main-content">
         <h4 class="subtitle">Janet 1.17.1-e1c4fc2 Documentation<br>(Other Versions:
-          
+
           <a href="../../1.16.1/docs/event_loop.html">1.16.1</a>
-          
+
           <a href="../../1.15.0/docs/event_loop.html">1.15.0</a>
-          
+
           <a href="../../1.13.1/docs/event_loop.html">1.13.1</a>
-          
+
           <a href="../../1.12.2/docs/event_loop.html">1.12.2</a>
-          
+
           <a href="../../1.11.1/docs/event_loop.html">1.11.1</a>
-          
+
           <a href="../../1.10.1/docs/event_loop.html">1.10.1</a>
-          
+
           <a href="../../1.9.1/docs/event_loop.html">1.9.1</a>
-          
+
           <a href="../../1.8.1/docs/event_loop.html">1.8.1</a>
-          
+
           <a href="../../1.7.0/docs/event_loop.html">1.7.0</a>
-          
+
           <a href="../../1.6.0/docs/event_loop.html">1.6.0</a>
-          
+
           <a href="../../1.5.1/docs/event_loop.html">1.5.1</a>
-          
+
           <a href="../../1.5.0/docs/event_loop.html">1.5.0</a>
-          
+
           <a href="../../1.4.0/docs/event_loop.html">1.4.0</a>
-          
+
           <a href="../../1.3.1/docs/event_loop.html">1.3.1</a>
           )</h4>
         <h1 class="subtitle">The Event Loop</h1>
@@ -87,7 +87,7 @@
 
           <span class="next"><a href="documentation.html"><span class="prevnext-text">Documentation</span></a></span>
         </div>
-        
+
 
 <p>In addition to threads, Janet comes with another powerful concurrency model out of the box - the event loop. The event loop provides
 concurrency within a single thread by allowing cooperating fibers to yield instead of
@@ -177,7 +177,7 @@ the network.
 </h2>
 <p>Channels are based around a queue abstraction, where producer tasks will add items to the channel with <code class="mendoza-code">ev/give</code>, and consumer tasks will remove items from the
 channel with <code class="mendoza-code">ev/take</code>. If there are no items in the channel when <code class="mendoza-code">ev/take</code> is called, the consumer will suspend until a producer gives an item
-to the channel. Similarly, if a task gives to a full channel, it will suspend until a consumer takes an item from the queue, freeing up space for the producer 
+to the channel. Similarly, if a task gives to a full channel, it will suspend until a consumer takes an item from the queue, freeing up space for the producer
 to put an item.
 </p>
 <p>Internally, channels are infinitely expanding queues, so one might think that they never need to be "full", but allowing channels to fill up and suspend writers
@@ -228,7 +228,7 @@ task to be resumed but immediately error. From the point of view of the canceled
 (<span class="mdzsyn-coresym">ev/sleep</span> <span class="mdzsyn-number">2</span>)
 (<span class="mdzsyn-coresym">ev/cancel</span> <span class="mdzsyn-symbol">f</span> <span class="mdzsyn-string">"canceled"</span>)</code></pre><h2 id="Supervisor-Channels">Supervisor Channels
 </h2>
-<p>An interesting problem with supporting multiple tasks is error handling - if a task raises and error (or any other uncaught signal), who should handle it? The programmer
+<p>An interesting problem with supporting multiple tasks is error handling - if a task raises an error (or any other uncaught signal), who should handle it? The programmer
 often wants to know when a task fails (or finishes), and then continue with some other code. Alternatively, it might be desirable to try again a number of times before
 really giving up.
 </p>
@@ -278,7 +278,7 @@ These events will be tuples of 2 arguments, <code class="mendoza-code">(signal f
       </div>
     </div>
 
-    
+
 <footer>
   &copy; Calvin Rose &amp; contributors 2021
   <div class="gentag">Generated on August 30, 2021 at 06:10:31 (UTC) with Janet 1.17.1-e1c4fc2</div>


### PR DESCRIPTION
Not sure I generated the PR correctly - I didn't run mendoza or anything, just fixed the 5 references in the source + static files.