### PR TITLE
Move event loop docs before threads

### DIFF
--- a/content/docs/event_loop.mdz
+++ b/content/docs/event_loop.mdz
@@ -1,6 +1,6 @@
 {:title "The Event Loop"
  :template "docpage.html"
- :order 21}
+ :order 19}
 ---
 
 Janet comes with a powerful concurrency model out of the box - the event loop. The event loop provides

--- a/content/docs/networking.mdz
+++ b/content/docs/networking.mdz
@@ -1,6 +1,6 @@
 {:title "Networking"
  :template "docpage.html"
- :order 20}
+ :order 21}
 ---
 
 The internet is a huge part of our daily lives in the 21st century, and the

--- a/content/docs/threads.mdz
+++ b/content/docs/threads.mdz
@@ -1,6 +1,6 @@
 {:title "Multithreading"
  :template "docpage.html"
- :order 19}
+ :order 20}
 ---
 
 Multithreading is the process of running a program on multiple threads at the same time, usually


### PR DESCRIPTION
An attempt to address https://github.com/janet-lang/janet-lang.org/issues/144