### PR TITLE
Fix links to cfunction sources

### DIFF
--- a/content/api/gen-docs.janet
+++ b/content/api/gen-docs.janet
@@ -62,7 +62,7 @@
                ;(if sm [{:tag "span" "class" "binding-type"
                          :content {:tag "a"
                                    "href" (string "https://github.com/janet-lang/janet/blob/" ver "/"
-                                                  (if (= "boot.janet" (get sm 0)) "src/boot/boot.janet" (get sm 0)) "#L" (sm 1))
+                                                  (if (= "boot.janet" (sm 0)) "src/boot/boot.janet" (sm 0)) "#L" (sm 1))
                                    :content "source"}}] []) " "
                {:tag "pre" "class" "binding-text" :content (or docstring "")}
                ;(if example [{:tag "div" "class" "example-title" :content "EXAMPLES"}

--- a/content/api/gen-docs.janet
+++ b/content/api/gen-docs.janet
@@ -61,8 +61,8 @@
                {:tag "span" "class" "binding-type" :content binding-type} " "
                ;(if sm [{:tag "span" "class" "binding-type"
                          :content {:tag "a"
-                                   "href" (string "https://github.com/janet-lang/janet/blob/"
-                                                  ver "/src/boot/boot.janet#L" (sm 1))
+                                   "href" (string "https://github.com/janet-lang/janet/blob/" ver "/"
+                                                  (if (= "boot.janet" (get sm 0)) "src/boot/boot.janet" (get sm 0)) "#L" (sm 1))
                                    :content "source"}}] []) " "
                {:tag "pre" "class" "binding-text" :content (or docstring "")}
                ;(if example [{:tag "div" "class" "example-title" :content "EXAMPLES"}


### PR DESCRIPTION
Currently, the function for generating GitHub links in the API docs assumes everything is defined in `/src/boot/boot.janet` and hard codes this as part of the URL. However, now that Janet includes source-maps for C functions, this results in incorrect links for these functions.

This PR fixes the links by testing whether the first entry in the source-map is `"boot.janet"` and if it is not, using the value of that first entry instead. Note that this test is necessary because bindings defined in `boot.janet` do not include the full path (i.e. `src/boot/boot.janet`). Perhaps they should but this would require changes to Janet itself.