### PR TITLE
Tweak Linux install info

### DIFF
--- a/content/docs/index.mdz
+++ b/content/docs/index.mdz
@@ -6,10 +6,8 @@
 
 ## Installation
 
-Install a stable version of Janet from the
-@link[https://github.com/janet-lang/janet/releases][releases page].  Janet is
-prebuilt for a few systems, but if you want to develop Janet, run Janet on a
-non-x86 system, or get the latest, you must build Janet from source.
+Janet is prebuilt for a few systems, but if you want to develop Janet, run Janet
+on a non-x86 system, or get the latest, you must build Janet from source.
 
 ### Windows
 
@@ -32,6 +30,10 @@ You can install either the latest git version or the latest stable version for
 Arch Linux from the Arch user repositories with
 @link[https://aur.archlinux.org/packages/janet-lang-git/][janet-lang-git] or
 @link[https://aur.archlinux.org/packages/janet-lang][janet-lang].
+
+#### Other Linux
+
+See instructions below for compiling and installing from source.
 
 ### macOS
 


### PR DESCRIPTION
@levitanong reported on the janet-language/help channel about experiences with using the releases `.tar.gz` for Linux.

bakpakin provided clarification regarding the intention of that `.tar.gz`:

> So there seems to be significant discussion about installing Janet releases using the Tarball on linux - my advice there is use the build instructions and build from source instead. The tarball is mainly for people scripting releases - and this is the case for most software on various unixes, simply because it is expected that distros will link to different libc versions, turn on different optimization flags, etc.

This PR is an attempt to tweak the existing installation docs to better reflect the above information.