### PR TITLE
Removed tilde from crazy symbol

### DIFF
--- a/content/docs/syntax.mdz
+++ b/content/docs/syntax.mdz
@@ -52,7 +52,7 @@ kebab-case-symbol
 snake_case_symbol
 my-module/my-function
 *****
-!%$^*__--__._+++===~-crazy-symbol
+!%$^*__--__._+++===-crazy-symbol
 *global-var*
 你好
 ```


### PR DESCRIPTION
The tilde `~` is not valid in symbols