### PR TITLE
fixed named arguments example in docs/functions

### DIFF
--- a/content/docs/functions.mdz
+++ b/content/docs/functions.mdz
@@ -330,8 +330,8 @@ preceded by a keyword of the same name.
 @codeblock[janet]```
 (defn named-fn
   [x &named person1 person2]
-  (print "giving " x " to person1)
-  (print "giving " x " to person2))
+  (print "giving " x " to person1")
+  (print "giving " x " to person2"))
 
 (name-fn "apple" :person1 "bob" :person2 "sally")
 ```


### PR DESCRIPTION
Just added two little small missing quotation marks that bothered me