### PR TITLE
Add missing parameter to ffi/signature call

### DIFF
--- a/content/docs/ffi.mdz
+++ b/content/docs/ffi.mdz
@@ -183,7 +183,7 @@ on each use.
 @codeblock[janet]```
 (def self-symbols (ffi/native))
 (def memcpy (ffi/lookup self-symbols "memcpy"))
-(def signature (ffi/signature :ptr :ptr :ptr :size))
+(def signature (ffi/signature :default :ptr :ptr :ptr :size))
 
 # Example usage of our memcpy binding
 (def buffer1 @"aaaa")


### PR DESCRIPTION
Was following along with the docs and found that as-is, the code wasn't working here.

Adding a parameter made things work.