### PR TITLE
Express NaN as math/nan

### DIFF
--- a/content/docs/syntax.mdz
+++ b/content/docs/syntax.mdz
@@ -204,7 +204,7 @@ Structs are represented by a sequence of whitespace-delimited key-value pairs
 surrounded by curly braces. The sequence is defined as key1, value1, key2,
 value2, etc.  There must be an even number of items between curly braces or the
 parser will signal a parse error. Any value can be a key or value. Using
-@code`nil` or @code`NaN` as a key, however, will drop that pair from the parsed
+@code`nil` or @code`math/nan` as a key, however, will drop that pair from the parsed
 struct.
 
 @codeblock[janet]```


### PR DESCRIPTION
May be it's a bit nicer to express `NaN` as `math/nan` as the latter can be used in Janet code while the former doesn't currently seem to work out-of-the-box in the manner implied by the text.