### PR TITLE
Add `\v` to list of things considered whitespace

### DIFF
--- a/content/docs/syntax.mdz
+++ b/content/docs/syntax.mdz
@@ -175,7 +175,8 @@ Yet another buffer
 
 Tuples are a sequence of whitespace separated values surrounded by either
 parentheses or brackets. The parser considers any of the characters ASCII 32,
-@code`\0`, @code`\f`, @code`\n`, @code`\r` or @code`\t` to be whitespace.
+@code`\0`, @code`\f`, @code`\n`, @code`\r`, @code`\t`, or @code`\v` to be
+whitespace.
 
 @codeblock[janet]```
 (do 1 2 3)


### PR DESCRIPTION
IIUC, `\v` is also [considered whitespace](https://github.com/janet-lang/janet/blob/f27b225b34968e38a3131bafa963d78f92e3f7d6/src/core/parse.c#L39).