### PR TITLE
Fix typos in ffi/write and ffi/read code blocks

### DIFF
--- a/content/docs/ffi.mdz
+++ b/content/docs/ffi.mdz
@@ -133,7 +133,7 @@ a @code`:ptr` type to a function.
 
 @codeblock[janet]```
 (ffi/context "./mylib.so")
-(def my-type (ffi/struct :char [@:int 4]))
+(def my-type (ffi/struct :char @[:int 4]))
 (ffi/defbind takes_a_pointer :void [a :ptr])
 (def buf (ffi/write my-type [100 [0 1 2 3]]))
 (takes_a_pointer buf)
@@ -148,7 +148,7 @@ address into Janet values.
 
 @codeblock[janet]```
 (ffi/context "./mylib.so")
-(def my-type (ffi/struct :char [@:int 4]))
+(def my-type (ffi/struct :char @[:int 4]))
 (ffi/defbind returns_a_pointer :ptr [])
 (def pointer (returns_a_pointer))
 (pp (ffi/read my-type pointer))


### PR DESCRIPTION
Currently, the sample code blocks on the Foreign Function Interface page contain invalid syntax:

<img width="595" alt="image" src="https://user-images.githubusercontent.com/55862180/223916297-ef1cea11-b698-49f3-9ff4-c0b60aba0c8f.png">

<img width="589" alt="image" src="https://user-images.githubusercontent.com/55862180/223916328-5f39128f-a980-467c-97d0-c92768c91660.png">

These snippets do not compile because the `@` is inside the `[`:

```
Janet 1.27.0-01aab666 linux/x64/gcc - '(doc)' for help
repl:1:> (def my-type (ffi/struct :char [@:int 4]))
repl:1:32: compile error: unknown symbol @:int
```

This PR fixes the sample code by moving the `@` outside the `[` in both code blocks:

```
Janet 1.27.0-01aab666 linux/x64/gcc - '(doc)' for help
repl:1:> (def my-type (ffi/struct :char @[:int 4]))
<core/ffi-struct 0x563C9B5EE910>
```