### PR TITLE
don't autofocus the search bar

### DIFF
--- a/templates/docpage.html
+++ b/templates/docpage.html
@@ -22,7 +22,7 @@
       <div class="bar"></div>
       <div class="bar botbar"></div>
     </div>
-    <iframe class="search-bar" src="https://duckduckgo.com/search.html?site=janet-lang.org&prefill=Search janet-lang.org&focus=yes" frameborder="0"></iframe> 
+    <iframe class="search-bar" src="https://duckduckgo.com/search.html?site=janet-lang.org&prefill=Search janet-lang.org" frameborder="0"></iframe>
     <script charset="utf-8">
       function toggleToc() {
         var toggler = document.getElementById('toc-toggle');


### PR DESCRIPTION
This prevents sharing links to individual functions using the URL fragment, as autofocusing the searchbox will scroll to the top of the page.

Fixes #170