### PR TITLE
Incorrect function referenced in `(product)` example

### DIFF
--- a/examples/product.janet
+++ b/examples/product.janet
@@ -7,4 +7,4 @@
 (product "hello") # -> 1.35996e+10
 
 # Product over values in a table or struct
-(sum {:a 1 :b 2 :c 4}) # -> 8
+(product {:a 1 :b 2 :c 4}) # -> 8


### PR DESCRIPTION
The example for the `(product)` function contains a reference to `(sum)`, but functioning in context the way one would expect `(product)` to function. This was potentially introduced as a copy/paste error.

<img width="611" alt="image" src="https://user-images.githubusercontent.com/55862180/229257329-d91a9184-031b-4f17-ad10-2c5149bd40c4.png">
