### PR TITLE
Update supervisor event description

### DIFF
--- a/content/docs/threads.mdz
+++ b/content/docs/threads.mdz
@@ -105,7 +105,7 @@ Thread supervisors need to be specified when creating the thread.
 (ev/thread worker nil :n supervisor)
 
 # Get one event from the supervisor channel (on the initial thread here)
-# It will either be (:error "oops!") or (:done nil).
+# It will either be (:error "oops!" nil) or (:ok nil nil).
 (def event (ev/take supervisor))
 (pp event)
 ```
@@ -113,9 +113,12 @@ Events from thread supervisors are much like events from normal fiber
 supervisors, but the first argument is not an entire copy of the fiber
 or thread, it is the event name. In the above example, depending on whether
 or not the "oops!" error was triggered, @code`event` will be either
-@code`(:error "oops!")` or @code`(:done nil)`. This corresponds to
-@code`[(fiber/status f) (fiber/last-value f)]` of the main fiber of the
-child thread.
+@code`(:error "oops!" nil)` or @code`(:ok nil nil)`. @code`:error` and
+@code`:ok` correspond to @code`(fiber/status f)`, while @code`"oops!"` and
+@code`nil` to @code`(fiber/last-value)` of the main fiber of the child
+thread.  The third element of the tuple is the associated
+task id, if the fiber has an associated environment, or @code`nil`
+otherwise.
 
 
 


### PR DESCRIPTION
In my local testing, I'm observing supervisor events that are tuples with 3 elements, though the current website docs describe such events as being tuples of two elements.  Perhaps things changed at some point (or may be I'm doing something wrong (^^; )

Also, the keyword that's the first element of the tuple seems to currently be `:ok` and not `:done` for the non-error case.

This PR is an attempt to reflect these findings in the docs.

I've tried to describe the third element of the tuple based on code from [here](https://github.com/janet-lang/janet/blob/cabbaded68947a7be3bee5c5b9e0dff0a3963c48/src/core/ev.c#L548-L552).  Happy to change to a better description :)