### PR TITLE
Update modules doc

### DIFF
--- a/content/docs/modules.mdz
+++ b/content/docs/modules.mdz
@@ -30,9 +30,10 @@ extensions, @code`jpm` will usually be much easier.
 
 ## Importing a module
 
-To use a module, the best way is use the @code`(import)` macro, which looks for
-a module with the given name on your system and imports its symbols into the
-current environment, usually prefixed with the name of the module.
+To use a module, the best way is to use the @code`(import)` macro,
+which looks for a module with the given name on your system and
+imports its symbols into the current environment, usually prefixed
+with the name of the module.
 
 @codeblock[janet]```
 (import path)
@@ -82,12 +83,13 @@ to Janet.
 
 ### @code`module/paths`
 
-This is an array of file paths to search for modules in the file system. Each
-element in this array is a tuple @code`[path type predicate]`, where @code`path`
-is a templated file path, which determines what path corresponds to a module
-name, and where type is the loading method used to load the module. @code`type`
-can be one of @code`:native`, @code`:source`, @code`:image`, or any key in the
-@code`module/loaders` table.
+This is an array of file paths to search for modules in the file
+system. Each element in this array is a tuple @code`[path type
+predicate]`, where @code`path` is a templated file path, which
+determines what path corresponds to a module name, and where
+@code`type` is the loading method used to load the module. @code`type`
+can be one of @code`:native`, @code`:source`, @code`:image`, or any
+key in the @code`module/loaders` table.
 
 @p{@code`predicate` is an optional function or file extension used to further
     filter whether or not a module name should match.  It's mainly useful when
@@ -116,20 +118,20 @@ the @code`:native` type is a wrapper around @code`native`.
 
 ### URL loader example
 
-An example from @code`examples/urlloader.janet` in the source repository shows
-how a loader can be a wrapper around curl and @code`dofile` to load source files
-from HTTP URLs.  To use it, simply evaluate this file somewhere in your program
-before you require code from a URL. Don't use this as is in production code, as
-if @code`url` contains spaces in @code`load-url` the module will not load
-correctly. A more robust solution would quote the URL, or better yet use
-@code`os/execute` and write to a temporary file instead of @code`file/popen`.
+An example from @code`examples/urlloader.janet` in the source
+repository shows how a loader can be a wrapper around curl and
+@code`dofile` to load source files from HTTP URLs.  To use it, simply
+evaluate this file somewhere in your program before you require code
+from a URL. Don't use this as-is in production code, because if
+@code`url` contains spaces in @code`load-url`, the module will not
+load correctly. A more robust solution would quote the URL.
 
 @codeblock[janet]```
 (defn- load-url
   [url args]
-  (def f (file/popen (string "curl " url)))
-  (def res (dofile f :source url ;args))
-  (try (file/close f) ([err] nil))
+  (def p (os/spawn ["curl" url "-s"] :p {:out :pipe}))
+  (def res (dofile (p :out) :source url ;args))
+  (:wait p)
   res)
 
 (defn- check-http-url
@@ -146,7 +148,7 @@ correctly. A more robust solution would quote the URL, or better yet use
 ## Relative imports
 
 You can include files relative to the current file by prefixing the module name
-with a @code`./`. For example, if you have a file tree that is structured like
+with @code`./`. For example, suppose you have a file tree that is structured like
 so:
 
 @codeblock```
@@ -158,7 +160,7 @@ mymod/
 ```
 
 With the above structure, @code`init.janet` can import @code`dep1` and
-@code`dep2` with relative imports. This is less brittle as the entire
+@code`dep2` with relative imports. This is robust because the entire
 @code`mymod/` directory can be installed without any chance that @code`dep1` and
 @code`dep2` will overwrite other files, or that @code`init.janet` will
 accidentally import a different file named @code`dep1.janet` or
@@ -196,7 +198,7 @@ pattern to allow this in a standalone executable built with @code`jpm` is as fol
 
 (defn main [& args]
   (put module/cache "mod1" mod1)
-  # now calls to (import1 mod1) at runtime will succeed.
+  # now calls to (import mod1) at runtime will succeed.
   (import mod1))
 ```
 
@@ -218,13 +220,14 @@ prefix the imported symbols with @code`local/`.
 
 ## Writing a module
 
-Writing a module in Janet is mostly about exposing only the public functions
-that you want users of your module to be able to use. All top level functions
-defined via @code`defn`, macros defined @code`defmacro`, constants defined via
-@code`def`, and vars defined via @code`var` will be exported in your module. To
-mark a function or binding as private to your module, you may use @code`defn-`
-or @code`def-` at the top level.  You can also add the @code`:private` metadata
-to the binding.
+Writing a module in Janet is mostly about exposing only the public
+functions that you want users of your module to be able to use. All
+top level functions defined via @code`defn`, macros defined via
+@code`defmacro`, constants defined via @code`def`, and vars defined
+via @code`var` will be exported in your module. To mark a function or
+binding as private to your module, you may use @code`defn-` or
+@code`def-` at the top level.  You can also add the keyword
+@code`:private` as metadata for the binding.
 
 Sample module:
 
@@ -232,39 +235,40 @@ Sample module:
 # Put imports and other requisite code up here
 
 (def api-constant
- "Some constant."
- 1000)
+  "Some constant."
+  1000)
 
 (def- private-constant
- "Not exported."
- :abc)
+  "Not exported."
+  :abc)
 
 (var *api-var*
- "Some API var. Be careful with these, dynamic bindings may be better."
- nil)
+  "Some API var. Be careful with these, dynamic bindings may be better."
+  nil)
 
 (var *private-var* :private
- "var that is not exported."
- 123)
+  "var that is not exported."
+  123)
 
 (defn- private-fun
- "Sum three numbers."
- [x y z]
- (+ x y z))
+  "Sum three numbers."
+  [x y z]
+  (+ x y z))
 
 (defn api-fun
- "Do a thing."
- [stuff]
- (+ 10 (private-fun stuff 1 2)))
+  "Do a thing."
+  [stuff]
+  (+ 10 (private-fun stuff 1 2)))
 ```
 
-To import our sample module given that it stored on disk at @code`mymod.janet`,
-we could do something like the following (this also works in a REPL):
+To import our sample module given that it is stored on disk at
+@code`mymod.janet`, we could do something like the following (this
+also works in a REPL):
 
 @codeblock[janet]```
 (import mymod)
 
-mymod/api-constant # evaluates to 10000
+mymod/api-constant # evaluates to 1000
 
 (mymod/api-fun 10) # evaluates to 23
 


### PR DESCRIPTION
This PR contains miscellaneous suggestions for the modules documentation.

Perhaps the most relevant change is for updating the code to the url loader example so that it no longer uses the deprecated `file/popen` call.  The changes were based on the content of [this file](https://github.com/janet-lang/janet/blob/15177ac2e9024d8f17ded07aefe07222f0dcda2e/examples/urlloader.janet).

The rest of the suggestions are fairly minor concerning prose, markup, and formatting (except in a couple of cases where the content of a comment was brought in line with relevant code).
