### PR TITLE
Tweak function names, code, table content, etc.

### DIFF
--- a/content/docs/data_structures/arrays.mdz
+++ b/content/docs/data_structures/arrays.mdz
@@ -48,7 +48,7 @@ arr # -> @[:one :two :three :four]
 Arrays are not of much use without being able to get and set values inside
 them. To get values from an array, use the @code`in` or @code`get` function.
 @code`in` will require an index within bounds and will throw an error
-otherwise. @code`get` requires an index and an optional default value. If the
+otherwise. @code`get` takes an index and an optional default value. If the
 index is out of bounds it will return @code`nil` or the given default value.
 
 @codeblock[janet](```

--- a/content/docs/data_structures/buffers.mdz
+++ b/content/docs/data_structures/buffers.mdz
@@ -54,7 +54,7 @@ sub strings (or sub buffers) from inside any sequence of bytes.
 
 @codeblock[janet](```
 (def buf @"abcdefg")
-(def buf1 (buffer/slice buf)) # -> @"abcdef", but a different buffer
+(def buf1 (buffer/slice buf)) # -> @"abcdefg", but a different buffer
 (def buf2 (buffer/slice buf 2)) # -> @"cdefg"
 (def buf3 (buffer/slice buf 2 -2)) # -> @"cdef"
 
@@ -91,7 +91,9 @@ There are also many functions to push data into a buffer. Since buffers are
 commonly used to accumulate data, there are a variety of functions for pushing
 data into a buffer.
 
-@ul{@li{@code[buffer/push-byte]}
+@ul{@li{@code[buffer/push]}
+    @li{@code[buffer/push-at]}
+    @li{@code[buffer/push-byte]}
     @li{@code[buffer/push-word]}
     @li{@code[buffer/push-string]}}
 

--- a/content/docs/data_structures/index.mdz
+++ b/content/docs/data_structures/index.mdz
@@ -47,12 +47,12 @@ data structure.
 @code[O(n)] time where @code[n] is the number of elements in the array.
 
 @codeblock[janet](```
-(def mytuple (tuple 1 2 3))
+(def my-tuple (tuple 1 2 3))
 
-(def myarray @(1 2 3))
-(def myarray (array 1 2 3))
+(def my-array @(1 2 3))
+(def my-array (array 1 2 3))
 
-(def mystruct {
+(def my-struct {
  :key "value"
  :key2 "another"
  1 2
@@ -103,10 +103,10 @@ prefer @code`in` for these.
 (in  @[:a :b :c] 3) # -> raises error
 ```
 
-To update a mutable data structure, use the @code[put] function. It takes 3
-arguments, the data structure, the key, and the value, and returns the data
-structure. The allowed types keys and values depend on the data structure passed
-in.
+To update a mutable data structure, use the @code[put] function. It
+takes 3 arguments, the data structure, the key, and the value, and
+returns the data structure. The allowed types of keys and values
+depend on the data structure passed in.
 
 @codeblock[janet]```
 (put @[] 100 :a)

--- a/content/docs/data_structures/tables.mdz
+++ b/content/docs/data_structures/tables.mdz
@@ -8,9 +8,9 @@ after the associative array or dictionary. Values are put into a table with a
 key, and can be looked up later with the same key. Tables are implemented with
 an underlying open hash table, so they are quite fast and cache friendly.
 
-Any Janet value except @code`nil` and @code`NaN` can be a key or a value in a
-Janet table, and a single Janet table can have any mixture of types as keys and
-values.
+Any Janet value except @code`nil` and @code`math/nan` can be a key or
+a value in a Janet table, and a single Janet table can have any
+mixture of types as keys and values.
 
 ## Creating tables
 
@@ -66,7 +66,7 @@ All tables can have a prototype, a parent table that is checked when a key is
 not found in the first table. By default, tables have no prototype.  Prototypes
 are a flexible mechanism that, among other things, can be used to implement
 inheritance in Janet. Read more in the
-@link[/docs/prototypes.html][documentation for prototypes]
+@link[/docs/prototypes.html][documentation for prototypes].
 
 ## Useful functions for tables
 

--- a/content/docs/data_structures/tuples.mdz
+++ b/content/docs/data_structures/tuples.mdz
@@ -3,9 +3,9 @@
 ---
 
 Tuples are immutable, sequential types that are similar to arrays. They are
-represented in source code with either parenthesis or brackets surrounding
+represented in source code with either parentheses or brackets surrounding
 their items. Note that Janet differs from traditional Lisps here, which
-commonly use the term "lists" to describe forms wrapped in parenthesis. Like
+commonly use the term "lists" to describe forms wrapped in parentheses. Like
 all data structures, tuple contents can be retrieved with the @code`get`
 function and their length retrieved with the @code`length` function.
 
@@ -86,7 +86,7 @@ tuples differ:
     @li{When printed via @code`pp`, bracket tuples are printed with square
         brackets instead of parentheses.}
     @li{When passed as an argument to @code`tuple/type`, bracket tuples will
-        returns @code`:brackets` instead of @code`:parens`.}}
+        return @code`:brackets` instead of @code`:parens`.}}
 
 In all other ways, bracketed tuples behave identically to normal tuples. It is
 not recommended to use bracketed tuples for anything outside of macros and

--- a/content/docs/event_loop.mdz
+++ b/content/docs/event_loop.mdz
@@ -21,7 +21,7 @@ All programs in Janet are wrapped in an implicit loop that will run until all ta
 describing how the event loop works - the event loop code is all actually implemented directly in the runtime for efficiency.
 
 @codeblock[janet]```
-# Functions that yield to the event loop will put (fiber/root-fiber) here.
+# Functions that yield to the event loop will put (fiber/root) here.
 (def pending-tasks @[])
 
 # Pseudo-code of the event loop scheduler
@@ -35,17 +35,21 @@ when an event (or sequence of events) that it is waiting for occurs. Generally, 
 resume tasks - the event loop will call @code`resume` when the completion event occurs.
 
 To be precise, a task is just any fiber that was scheduled to run by the event loop.
-Therefore, all tasks are fibers, but not all fibers are tasks. You can get the currently executing task in Janet with @code`(fiber/root-fiber)`.
+Therefore, all tasks are fibers, but not all fibers are tasks. You can get the currently executing task in Janet with @code`(fiber/root)`.
 
 ## Blocking the Event Loop
 
-When using the event loop, it is important to be aware that CPU bound loops will block all other tasks on the
-event loop. For example, an infinite while loop that does not yield to the event will bring the entire thread to a halt!
-This is generally considered to be one of the biggest drawbacks to cooperative multi-threading, so be cautious and do not mix in
-blocking functions into a program that uses the event loop. Many functions in Janet's core library will not block when the event loop is enabled, but
-a few will. All functions in the @code`file/` module will block, so be careful when using these with networked files.
-These
-functions may be changed or deprecated in the future. Other blocking functions include @code`os/sleep` and
+When using the event loop, it is important to be aware that CPU bound
+loops will block all other tasks on the event loop. For example, an
+infinite while loop that does not yield to the event loop will bring
+the entire thread to a halt!  This is generally considered to be one
+of the biggest drawbacks to cooperative multi-threading, so be
+cautious and do not mix in blocking functions into a program that uses
+the event loop. Many functions in Janet's core library will not block
+when the event loop is enabled, but a few will. All functions in the
+@code`file/` module will block, so be careful when using these with
+networked files.  These functions may be changed or deprecated in the
+future. Other blocking functions include @code`os/sleep` and
 @code`getline`.
 
 NOTE: This means that getting input from the repl will block the event loop! Be careful of this when trying to use @code`ev/` functions
@@ -124,6 +128,8 @@ allows for back pressure. Back pressure means that a task can indicate to other 
 
 (ev/call consumer "bob" 1)
 (ev/call consumer "sally" 0.63)
+
+# Call (ev/sleep 1) to see some results
 ```
 
 ## Streams
@@ -139,8 +145,12 @@ For some examples on how to use streams, see documentation on @link[networking.h
 
 ## Cancellation
 
-Sometimes, IO operations can take too long or even hang indefinitely. Janet offers @code`ev/cancel` to interrupt and cancel an ongoing IO operation. This will cause the canceled
-task to be resumed but immediately error. From the point of view of the canceled task, it will look as though the last function that yielded to event loop raised an error.
+Sometimes, IO operations can take too long or even hang
+indefinitely. Janet offers @code`ev/cancel` to interrupt and cancel an
+ongoing IO operation. This will cause the canceled task to be resumed
+but immediately error. From the point of view of the canceled task, it
+will look as though the last function that yielded to the event loop
+raised an error.
 
 Macros like @code`try` and @code`protect` will continue to work just as if the cancellation error was any other error.
 
@@ -162,9 +172,14 @@ An interesting problem with supporting multiple tasks is error handling - if a t
 often wants to know when a task fails (or finishes), and then continue with some other code. Alternatively, it might be desirable to try again a number of times before
 really giving up.
 
-Janet has the concept of supervisor channels to support this. When a new task is scheduled with @code`ev/go`, one can optional specify a channel to set as the new tasks supervisor.
-When the task yields to the event loop, or raises any kind of fiber signal, a message is automatically written to the supervisor channel. Another task can then continuously listen on that
-channel to monitor other tasks, handling errors or restarting them. This is a powerful pattern that can be used to build robust applications that gracefully handle failure.
+Janet has the concept of supervisor channels to support this. When a
+new task is scheduled with @code`ev/go`, one can optionally specify a
+channel to set as the new tasks supervisor.  When the task yields to
+the event loop, or raises any kind of fiber signal, a message is
+automatically written to the supervisor channel. Another task can then
+continuously listen on that channel to monitor other tasks, handling
+errors or restarting them. This is a powerful pattern that can be used
+to build robust applications that gracefully handle failure.
 
 @codeblock[janet]```
 (def channel (ev/chan))

--- a/content/docs/ffi.mdz
+++ b/content/docs/ffi.mdz
@@ -11,15 +11,19 @@ Programmers should be aware of this before choosing FFI bindings over a traditio
 native module. It is also possible to use a hybrid approach, where some core functionality is exposed via a
 C extension module, and the majority of an API is bound via FFI.
 
-The FFI Module contains both the low-level primitives to load dynamic libraries (as with @code`dlopen` on posix systems), get
-function pointers from those modules, and call those function pointers. On top of this, there is a macro based abstraction that makes it convenient to declare bindings and is sufficient in most cases.
+The FFI Module contains both the low-level primitives to load dynamic
+libraries (as with @code`dlopen` on posix systems), get function
+pointers from those modules, and call those function pointers. On top
+of this, there is a macro-based abstraction that makes it convenient
+to declare bindings and is sufficient in most cases.
 
 ## Primitive Types
 
-Primitive types in the FFI syntax are specified with keywords, and map directly to primitive
-type in C. There are a number of aliases for common types, such as the Linux kernel source style aliases
-for sized integer types. More complex types can be built of from these primitive types. On x86-64, long
-doubles are unsupported.
+Primitive types in the FFI syntax are specified with keywords, and map
+directly to primitive type in C. There are a number of aliases for
+common types, such as the Linux kernel source style aliases for sized
+integer types. More complex types can be built from these primitive
+types. On x86-64, long doubles are unsupported.
 
 @tag[table]{
     @tr{@th{Primitive Type} @th{Corresponding C Type}}

--- a/content/docs/gen-asm-table.janet
+++ b/content/docs/gen-asm-table.janet
@@ -61,7 +61,7 @@
    ['next '(next dest ds key) "$dest = next($ds, $key)"]
    ['noop '(noop) "Does nothing."]
    ['prop '(prop val fiber) "Propagate (Re-raise) a signal that has been caught."]
-   ['push '(push val) "Push $val on arg"]
+   ['push '(push val) "Push $val on args"]
    ['push2 '(push2 val1 val2) "Push $val1, $val2 on args"]
    ['push3 '(push3 val1 val2 val3) "Push $val1, $val2, $val3, on args"]
    ['pusha '(pusha array) "Push values in $array on args"]

--- a/content/docs/gen-asm-table.janet
+++ b/content/docs/gen-asm-table.janet
@@ -20,7 +20,6 @@
    ['divim '(divim dest lhs im) "$dest = $lhs / im"]
    ['eq '(eq dest lhs rhs) "$dest = $lhs == $rhs"]
    ['eqim '(eqim dest lhs im) "$dest = $lhs == im"]
-   ['eqn '(eqn dest lhs im) "$dest = $lhs .== $rhs"]
    ['err '(err message) "Throw error $message."]
    ['get '(get dest ds key) "$dest = $ds[$key]"]
    ['geti '(geti dest ds index) "$dest = $ds[index]"]

--- a/content/docs/index.mdz
+++ b/content/docs/index.mdz
@@ -83,7 +83,7 @@ After building, run @code[make install] to install the @code`janet` binary and
 libraries.  This will install in @code[/usr/local] by default, see the Makefile
 to customize.
 
-Next, to install the Janet Package Manager tool (@code`jpm`), clone the
+Next, to install the Janet Project Manager tool (@code`jpm`), clone the
 @link[https://github.com/janet-lang/jpm][jpm repository], and from within that
 directory, run:
 

--- a/content/docs/jpm.mdz
+++ b/content/docs/jpm.mdz
@@ -15,9 +15,11 @@ cd jpm
 sudo janet bootstrap.janet
 ```
 
-The bootstrap script can also be configured to install jpm to different directories by setting the
-@code`DESTDIR` environment variable. Ideally, jpm should be installed to the same tree as Janet, although
-this is not strictly required. See the JPM README in the repository for more information.
+The bootstrap script can also be configured to install jpm to
+different directories by setting the @code`DESTDIR` environment
+variable. Ideally, jpm should be installed to the same tree as Janet,
+although this is not strictly required. See the README in jpm's
+repository for more information.
 
 ## Updating JPM
 
@@ -38,14 +40,15 @@ sudo jpm install jpm
 
 ## Glossary
 
-A self contained unit of Janet source code as recognized by @code`jpm` is called
-a project. A project is a directory containing a @code`project.janet` file,
-which contains build recipes. Often, a project will correspond to a single git
-repository, and contain a single library. However, a project's
-@code`project.janet` file can contain build recipes for as many libraries,
-native extensions, and executables as it wants. Each of these recipes builds an
-artifact. Artifacts are the output files that will either be distributed or
-installed on the end-user or developer's machine.
+A self-contained unit of Janet source code as recognized by @code`jpm`
+is called a project. A project is a directory containing a
+@code`project.janet` file, which contains build recipes. Often, a
+project will correspond to a single git repository, and contain a
+single library. However, a project's @code`project.janet` file can
+contain build recipes for as many libraries, native extensions, and
+executables as it wants. Each of these recipes builds an
+artifact. Artifacts are the output files that will either be
+distributed or installed on the end-user or developer's machine.
 
 ## Building projects with @code`jpm`
 
@@ -301,12 +304,16 @@ to libraries as backwards-compatible as possible, and release new libraries for 
 cases. For creators of executable programs (versus a library author), it is recommended to use a local tree
 and lockfiles to pin versions for consistent builds.
 
-As a matter of style, it is also recommended to group small libraries together into "bundles"
-that are updated, tested, and deployed together. Since Janet libraries are often quite small, the cost of
-downloading more functionality that one might need isn't particularly high, and JPM can remove unused functions
-and bindings from generated standalone binaries and images, so there is not runtime cost either. By avoiding
-a plethora of tiny libraries, users of libraries do not manage as many dependencies, and modules are more
-likely to work together they can be tested together.
+As a matter of style, it is also recommended to group small libraries
+together into "bundles" that are updated, tested, and deployed
+together. Since Janet libraries are often quite small, the cost of
+downloading more functionality that one might need isn't particularly
+high, and JPM can remove unused functions and bindings from generated
+standalone binaries and images, so there is no runtime cost either. By
+avoiding a plethora of tiny libraries, users of libraries do not
+manage as many dependencies, and modules are more likely to work
+together they can be tested together.
 
-While @code`jpm` may superficially resemble @code`npm`, it is the authors opinion that it is suited
-to a different style of development.
+While @code`jpm` may superficially resemble @code`npm`, it is the
+author's opinion that it is suited to a different style of
+development.

--- a/content/docs/linting.mdz
+++ b/content/docs/linting.mdz
@@ -71,8 +71,8 @@ arguments and assert that certain invariants are held when invoking a macro.
  ~(,+ ,x ,y))
 ```
 
-Use of @code`maclintf` over other methods of reporting warnings is preferred as the programmer has the
-ability to customize how the handle different levels of lint messages.
-For fatal errors inside the macro, use
-the @code`error` function as usual.
+Use of @code`maclintf` over other methods of reporting warnings is
+preferred as the programmer has the ability to customize how to handle
+different levels of lint messages.  For fatal errors inside the macro,
+use the @code`error` function as usual.
 

--- a/content/docs/loop.mdz
+++ b/content/docs/loop.mdz
@@ -26,17 +26,17 @@ For our first version, we will use only the @code`while` form to iterate,
 similar to how one might sum natural numbers in a language such as C.
 
 @codeblock[janet]```
-(var sum 0)
+(var total 0)
 (var i 0)
 (while (< i 10)
-    (+= sum i)
+    (+= total i)
     (++ i))
-(print sum) # prints 45
+(print total) # prints 45
 ```
 
 This is a very imperative program, and it is not the best way to write this in
 Janet.  We are manually updating a counter @code[i] in a loop. Using the macros
-@code[+=] and @code[++], this style code is similar in density to C code.  It is
+@code[+=] and @code[++], this style of code is similar in density to C code.  It is
 recommended to instead use either macros (such as the @code`loop` or @code`for`
 macros) or a functional style in Janet.
 
@@ -45,9 +45,9 @@ The @code[(for x start end body)] form captures this behavior of incrementing a
 counter in a loop.
 
 @codeblock[janet]```
-(var sum 0)
-(for i 0 10 (+= sum i))
-(print sum) # prints 45
+(var total 0)
+(for i 0 10 (+= total i))
+(print total) # prints 45
 ```
 
 We have completely wrapped the imperative counter in a macro. The @code`for`
@@ -59,9 +59,9 @@ loop.
 We can do something similar with the more flexible @code`loop` macro.
 
 @codeblock[janet]```
-(var sum 0)
-(loop [i :range [0 10]] (+= sum i))
-(print sum) # prints 45
+(var total 0)
+(loop [i :range [0 10]] (+= total i))
+(print total) # prints 45
 ```
 
 This is slightly more verbose than the @code`for` macro, but can be more easily
@@ -69,17 +69,17 @@ extended.  Let's say that we wanted to only count even numbers towards the sum.
 We can do this easily with the @code`loop` macro.
 
 @codeblock[janet]```
-(var sum 0)
-(loop [i :range [0 10] :when (even? i)] (+= sum i))
-(print sum) # prints 20
+(var total 0)
+(loop [i :range [0 10] :when (even? i)] (+= total i))
+(print total) # prints 20
 ```
 
-The @code`loop` macro has several verbs (@code`:range`) and modifiers
-(@code`:when`) that let the programmer more easily generate common looping
-idioms. The @code`loop` macro is similar to the Common Lisp @code`loop` macro,
-but smaller in scope and with a much simpler syntax. As with the @code`for`
-macro, the @code`loop` macro expands to similar code as our original
-@code`while` expression.
+The @code`loop` macro has several verbs (e.g. @code`:range`) and
+modifiers (e.g. @code`:when`) that let the programmer more easily
+generate common looping idioms. The @code`loop` macro is similar to
+the Common Lisp @code`loop` macro, but smaller in scope and with a
+much simpler syntax. As with the @code`for` macro, the @code`loop`
+macro expands to similar code as our original @code`while` expression.
 
 ## Example 2: Iterating over an indexed data structure
 
@@ -213,3 +213,14 @@ Notice that iteration through the table is in no particular order. Iterating the
 keys of a table or struct guarantees no order. If you want to iterate in a
 specific order, use a different data structure or the @code[(sort indexed)]
 function.
+
+Note that the above examples can also be expressed as:
+
+@codeblock[janet]```
+(loop [[letter word] :pairs alphabook]
+  (print letter " is for " word))
+
+(loop [letter :keys alphabook]
+  (print letter " is for " (alphabook letter)))
+```
+

--- a/content/docs/networking.mdz
+++ b/content/docs/networking.mdz
@@ -7,14 +7,17 @@ The internet is a huge part of our daily lives in the 21st century, and the
 situation is no different for programmers. Janet has basic
 support for connecting to the internet out of the box with the @code`net/` module.
 
-The @code`net/` module provides a socket-based networking interface that is portable, simple, and
-general. The net module provides both client and server abstractions for TCP sockets
-(streams), UDP (datagrams), IPv4, IPv6, DNS, and unix domain sockets on supported platforms.
-All operations on sockets are non-blocking, so servers can handle multiple clients on a single thread.
-For more general information on
-socket programming, see @link[https://beej.us/guide/bgnet/html/]{Beej's Guide to Network Programming}, which
-gives a thorough overview in C. There are also example programs in example directory of the Janet source
-code which show how to create simple servers and clients.
+The @code`net/` module provides a socket-based networking interface
+that is portable, simple, and general. The net module provides both
+client and server abstractions for TCP sockets (streams), UDP
+(datagrams), IPv4, IPv6, DNS, and unix domain sockets on supported
+platforms.  All operations on sockets are non-blocking, so servers can
+handle multiple clients on a single thread.  For more general
+information on socket programming, see
+@link[https://beej.us/guide/bgnet/html/]{Beej's Guide to Network
+Programming}, which gives a thorough overview in C. There are also
+example programs in the example directory of the Janet source code
+which show how to create simple servers and clients.
 
 The @code`net/` module does not provide any protocol abstractions over sockets - this means
 no TLS and no HTTP out of the box. Such protocols need to be provided in third-party libraries.

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -78,10 +78,10 @@ languages.
     @tr{@th{Pattern Signature}
         @th{What it matches}}
 
-    @tr{@td{string ("cat")}
+    @tr{@td{"cat" (a string)}
         @td{ The literal string. }}
 
-    @tr{@td{integer (3)}
+    @tr{@td{3 (an integer)}
         @td{ Matches a number of characters, and advances that many characters.
         If negative, matches if not that many characters and does not advance.
         For example, -1 will match the end of a string. }}
@@ -295,6 +295,9 @@ grammars simpler.
         @td{ Duplicates the last capture with the tag @code`tag`. If no such
         capture exists then the match fails. }}
 
+    @tr{@td{@code`(-> tag ?tag)` }
+        @td{ Alias for @code`(backref tag)`. }}
+
     @tr{@td{@code`(unref patt ?tag)` }
         @td{Lets a user "scope" tagged captures.
         After the rule has matched, all captures with the given tag can no longer be
@@ -304,35 +307,36 @@ grammars simpler.
         removes their association with the tag. This means subsequent calls to
         backref and backmatch will no longer "see" these tagged captures. }}
 
-    @tr{@td{@code`(-> tag ?tag)` }
-        @td{ Alias for @code`(backref tag)`. }}
-
     @tr{@td{@code`(error ?patt)` }
         @td{ Throws a Janet error.  If optional argument @code`patt` is
         provided and it matches successfully, the error thrown will be the
         last capture of @code`patt`, or a generic error if @code`patt`
         produces no captures. If no argument is provided, a generic error is
-        thrown.
+        thrown. If @code`patt` does not match, no error will be thrown.
         }}
 
     @tr{@td{@code`(drop patt)` }
         @td{ Ignores (drops) all captures from patt. }}
 
-    @tr{@td{@code`(uint num-bytes)` }
-        @td{ Capture a little endian, unsigned, two's complement integer from @code`num-bytes`. Works for 1 to 8 byte integers. }}
+    @tr{@td{@code`(uint num-bytes ?tag)` }
+        @td{ Capture a little endian, unsigned, two's complement integer from 
+        @code`num-bytes`. Works for 1 to 8 byte integers. }}
 
-    @tr{@td{@code`(uint-be num-bytes)` }
-        @td{ Capture a big endian, unsigned, two's complement integer from @code`num-bytes`. Works for 1 to 8 byte integers. }}
+    @tr{@td{@code`(uint-be num-bytes ?tag)` }
+        @td{ Capture a big endian, unsigned, two's complement integer from 
+        @code`num-bytes`. Works for 1 to 8 byte integers. }}
 
-    @tr{@td{@code`(int num-bytes)` }
-        @td{ Capture a little endian, signed, two's complement integer from @code`num-bytes`. Works for 1 to 8 byte integers. }}
+    @tr{@td{@code`(int num-bytes ?tag)` }
+        @td{ Capture a little endian, signed, two's complement integer from 
+        @code`num-bytes`. Works for 1 to 8 byte integers. }}
 
-    @tr{@td{@code`(int-be num-bytes)` }
-        @td{ Capture a big endian, signed, two's complement integer from @code`num-bytes`. Works for 1 to 8 byte integers. }}
+    @tr{@td{@code`(int-be num-bytes ?tag)` }
+        @td{ Capture a big endian, signed, two's complement integer from 
+        @code`num-bytes`. Works for 1 to 8 byte integers. }}
 
-    @tr{@td{@code`(lenprefix n patt)` }
+    @tr{@td{@code`(lenprefix n patt ?tag)` }
         @td{ Matches n repetitions of a pattern, where n is supplied from other
-        parsed input and is not a constant. }}}
+        parsed input and is not a constant. }}
 
     @tr{@td{@code`(number patt ?base ?tag)` }
         @td{ Capture a number parsed from the matched pattern. This uses the
@@ -429,7 +433,7 @@ in patterns.
 
 (peg/match where-are-the-dogs? "dog dog cat dog") # -> @[0 4 12]
 
-# Our finder function also works any pattern, not just strings.
+# Our finder function also works on any pattern, not just strings.
 
 (def find-cats (finder '(* "c" (some "a") "t")))
 

--- a/content/docs/strings.mdz
+++ b/content/docs/strings.mdz
@@ -43,7 +43,7 @@ as a key into a table or struct.
 # Evaluates to false, everything in janet is case sensitive
 (= :hello :HeLlO)
 
-# Look up into a table - evaluates to 25
+# Look up into a struct - evaluates to 25
 (get {
     :name "John"
     :age 25
@@ -64,7 +64,7 @@ defining either text or arbitrary sequences of bytes. Strings (and symbols) in
 Janet are what is sometimes known as "8-bit clean"; they can hold any number of
 bytes, and are completely unaware of things like character encodings. This is
 completely compatible with ASCII and UTF-8, two of the most common character
-encodings. By being encoding agnostic, Janet strings can be simple, fast, and
+encodings. By being encoding-agnostic, Janet strings can be simple, fast, and
 useful for other uses besides holding text.
 
 Literal text can be entered inside double quotes, as we have seen above.


### PR DESCRIPTION
This PR contains a variety of suggestions (trying to align with [this](https://github.com/janet-lang/janet/blob/master/CONTRIBUTING.md#typo-fixing-and-one-line-changes)).

Among other things it contains:

* Changes to some code samples for consistency (e.g. tweak some naming, avoiding shadowing of built-in names, comments matching actual behavior, etc.)
* Changes to some identifiers (e.g. `fiber/root` instead of `fiber/root-fiber`, `math/nan` instead of `NaN`)
* Changes to one of the PEG tables (e.g. adding some missing info, swapping order of two rows, fixing the table where a row had leaked out, etc.)
* Change "Janet Package Manager" to "Janet Project Manager" to match the name in the jpm repository
