### PR TITLE
Update and ascii-sort string escapes in peg

### DIFF
--- a/content/docs/syntax.mdz
+++ b/content/docs/syntax.mdz
@@ -285,7 +285,7 @@ EBNF.  More info on the PEG syntax can be found in the @link[/docs/peg.html][PEG
     :symchars (+ (range "09" "AZ" "az" "\x80\xFF") (set "!$%&*+-./:<?=>@^_"))
     :token (some :symchars)
     :hex (range "09" "af" "AF")
-    :escape (* "\\" (+ (set "ntrzfev0\"\\")
+    :escape (* "\\" (+ (set `"'0?\abefnrtvz`)
                        (* "x" :hex :hex)
                        (* "u" [4 :hex])
                        (* "U" [6 :hex])


### PR DESCRIPTION
Some escape sequences were added to Janet in [d6337e77](https://github.com/janet-lang/janet/commit/d63379e7777b1269ad4e8e075c971503b1732c30).  This PR is an attempt to update the PEG for Janet on the syntax page.

As the number of items is increasing, it seemed prudent to sort the items to make maintenance easier (e.g. avoidance of duplicates, locating a particular item, etc.).  The sorting order chosen was based on what was found via the ascii(7) man page.

In an attempt to reduce the amount of "backslashing", also changed the string delimiter to backtick.
