### PR TITLE
Keep identifiers with solidi from being split up

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -255,6 +255,7 @@ code {
 .mendoza-code {
     padding: 0 5px;
     background: #EEE;
+    white-space: nowrap;
 }
 
 .mendoza-codeblock {


### PR DESCRIPTION
This is an attempt to address #216.