### PR TITLE
Remove community example links from some docs

### DIFF
--- a/content/api/gen-docs.janet
+++ b/content/api/gen-docs.janet
@@ -86,7 +86,8 @@
                        (type val))
         docstring (remove-extra-spaces docstring)
         source-linker (dyn :source-linker janet-source-linker)
-        example (check-example key)]
+        example (check-example key)
+        c-example (not (dyn :no-community-examples))]
     {:tag "div" "class" "binding"
      :content [{:tag "span" "class" "binding-sym" "id" key :content key} " "
                {:tag "span" "class" "binding-type" :content binding-type} " "
@@ -98,8 +99,10 @@
                ;(if example [{:tag "div" "class" "example-title" :content "EXAMPLES"}
                              {:tag "pre" "class" "mendoza-codeblock"
                               :content {:tag "code" :language (require "janet.syntax") :content (string example)}}] [])
-
-               {:tag "a" "href" (string "https://janetdocs.com/" (jdoc-escape key)) :content "Community Examples"}]}))
+               (if c-example
+                 {:tag "a" "href"
+                  (string "https://janetdocs.com/" (jdoc-escape key))
+                  :content "Community Examples"})]}))
 
 (defn- all-entries 
   [&opt env]

--- a/content/api/jpm/cc.mdz
+++ b/content/api/jpm/cc.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import jpm/cc :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/jpm" gen-docs/jpm-version))
+(setdyn :no-community-examples true)
 
 {:title "C Compiler"
  :nav-title "cc"

--- a/content/api/jpm/cgen.mdz
+++ b/content/api/jpm/cgen.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import jpm/cgen :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/jpm" gen-docs/jpm-version))
+(setdyn :no-community-examples true)
 
 {:title "C Source Generation"
  :nav-title "cgen"

--- a/content/api/jpm/cli.mdz
+++ b/content/api/jpm/cli.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import jpm/cli :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/jpm" gen-docs/jpm-version))
+(setdyn :no-community-examples true)
 
 {:title "Command Line Interface"
  :nav-title "cli"

--- a/content/api/jpm/commands.mdz
+++ b/content/api/jpm/commands.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import jpm/commands :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/jpm" gen-docs/jpm-version))
+(setdyn :no-community-examples true)
 
 {:title "Commands"
  :nav-title "commands"

--- a/content/api/jpm/config.mdz
+++ b/content/api/jpm/config.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import jpm/config :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/jpm" gen-docs/jpm-version))
+(setdyn :no-community-examples true)
 
 {:title "Config"
  :nav-title "config"

--- a/content/api/jpm/dagbuild.mdz
+++ b/content/api/jpm/dagbuild.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import jpm/dagbuild :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/jpm" gen-docs/jpm-version))
+(setdyn :no-community-examples true)
 
 {:title "DAG Build"
  :nav-title "dagbuild"

--- a/content/api/jpm/index.mdz
+++ b/content/api/jpm/index.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import jpm :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/jpm" gen-docs/jpm-version))
+(setdyn :no-community-examples true)
 
 {:title "JPM"
  :nav-title "jpm"

--- a/content/api/jpm/make-config.mdz
+++ b/content/api/jpm/make-config.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import jpm/make-config :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/jpm" gen-docs/jpm-version))
+(setdyn :no-community-examples true)
 
 {:title "Configuration Generation"
  :nav-title "make-config"

--- a/content/api/jpm/pm.mdz
+++ b/content/api/jpm/pm.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import jpm/pm :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/jpm" gen-docs/jpm-version))
+(setdyn :no-community-examples true)
 
 {:title "Project Management"
  :nav-title "pm"

--- a/content/api/jpm/rules.mdz
+++ b/content/api/jpm/rules.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import jpm/rules :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/jpm" gen-docs/jpm-version))
+(setdyn :no-community-examples true)
 
 {:title "Build Rules"
  :nav-title "rules"

--- a/content/api/jpm/scaffold.mdz
+++ b/content/api/jpm/scaffold.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import jpm/scaffold :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/jpm" gen-docs/jpm-version))
+(setdyn :no-community-examples true)
 
 {:title "Project Scaffolding"
  :nav-title "scaffold"

--- a/content/api/jpm/shutil.mdz
+++ b/content/api/jpm/shutil.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import jpm/shutil :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/jpm" gen-docs/jpm-version))
+(setdyn :no-community-examples true)
 
 {:title "Shell Utilities"
  :nav-title "shutil"

--- a/content/api/spork/argparse.mdz
+++ b/content/api/spork/argparse.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/argparse :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Argument Parsing"
  :nav-title "argparse"

--- a/content/api/spork/base64.mdz
+++ b/content/api/spork/base64.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/base64 :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Base64"
  :nav-title "base64"

--- a/content/api/spork/crc.mdz
+++ b/content/api/spork/crc.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/crc :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "CRC"
  :nav-title "crc"

--- a/content/api/spork/cron.mdz
+++ b/content/api/spork/cron.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/cron :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Cron"
  :nav-title "cron"

--- a/content/api/spork/ev-utils.mdz
+++ b/content/api/spork/ev-utils.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/ev-utils :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "EV Utilities"
  :nav-title "ev-utils"

--- a/content/api/spork/fmt.mdz
+++ b/content/api/spork/fmt.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/fmt :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Format"
  :nav-title "fmt"

--- a/content/api/spork/generators.mdz
+++ b/content/api/spork/generators.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/generators :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Generators"
  :nav-title "generators"

--- a/content/api/spork/getline.mdz
+++ b/content/api/spork/getline.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/getline :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Getline"
  :nav-title "getline"

--- a/content/api/spork/htmlgen.mdz
+++ b/content/api/spork/htmlgen.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/htmlgen :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "HTML Generation"
  :nav-title "htmlgen"

--- a/content/api/spork/http.mdz
+++ b/content/api/spork/http.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/http :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "HTTP"
  :nav-title "http"

--- a/content/api/spork/httpf.mdz
+++ b/content/api/spork/httpf.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/httpf :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "HTTP Framework"
  :nav-title "httpf"

--- a/content/api/spork/index.mdz
+++ b/content/api/spork/index.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Spork"
  :nav-title "spork"

--- a/content/api/spork/json.mdz
+++ b/content/api/spork/json.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/json :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "JSON"
  :nav-title "json"

--- a/content/api/spork/math.mdz
+++ b/content/api/spork/math.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/math :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Math extended"
  :nav-title "math"

--- a/content/api/spork/misc.mdz
+++ b/content/api/spork/misc.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/misc :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Miscellaneous Functions"
  :nav-title "misc"

--- a/content/api/spork/msg.mdz
+++ b/content/api/spork/msg.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/msg :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Simple Messaging Protocol"
  :nav-title "msg"

--- a/content/api/spork/netrepl.mdz
+++ b/content/api/spork/netrepl.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/netrepl :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "NetREPL"
  :nav-title "netrepl"

--- a/content/api/spork/path.mdz
+++ b/content/api/spork/path.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/path :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Path Utilities"
  :nav-title "path"

--- a/content/api/spork/rawterm.mdz
+++ b/content/api/spork/rawterm.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/rawterm :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Raw Terminal Functionality"
  :nav-title "rawterm"

--- a/content/api/spork/regex.mdz
+++ b/content/api/spork/regex.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/regex :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Regular Expression PEG Syntax"
  :nav-title "regex"

--- a/content/api/spork/rpc.mdz
+++ b/content/api/spork/rpc.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/rpc :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Remote Procedure Calls"
  :nav-title "rpc"

--- a/content/api/spork/schema.mdz
+++ b/content/api/spork/schema.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/schema :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Schema"
  :nav-title "schema"

--- a/content/api/spork/sh.mdz
+++ b/content/api/spork/sh.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/sh :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Shell Utilities"
  :nav-title "sh"

--- a/content/api/spork/tarray.mdz
+++ b/content/api/spork/tarray.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/tarray :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Typed Arrays"
  :nav-title "tarray"

--- a/content/api/spork/test.mdz
+++ b/content/api/spork/test.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/test :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Test"
  :nav-title "test"

--- a/content/api/spork/zip.mdz
+++ b/content/api/spork/zip.mdz
@@ -1,6 +1,7 @@
 (import ../gen-docs :as gen-docs)
 (import spork/zip :export true)
 (setdyn :source-linker (partial gen-docs/github-source-linker "janet-lang/spork" gen-docs/spork-version))
+(setdyn :no-community-examples true)
 
 {:title "Zip Files"
  :nav-title "zip"


### PR DESCRIPTION
This is an attempt to address #195.

The idea is to not have the community example links show up for `jpm` and `spork` docs.

Each `jpm` and `spork` file had a line like this:

```janet
(setdyn :no-community-examples true)
```

added.  `emit-item` in `gen-docs.janet` was modified so that it only adds community example links in certain cases.

(This approach is similar to what is described in [this comment](https://github.com/janet-lang/janet-lang.org/issues/195#issuecomment-2167477932), but slightly different.  Basic mechanism is the same though.)
