### PR TITLE
Update look peg special docs

### DIFF
--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -178,13 +178,14 @@ compiled to bytecode).
     @tr{@td{@code`(! patt)` }
     @td{ Alias for @code`(not patt)` }}
 
-    @tr{@td{@code`(look offset patt)` }
-        @td{ Matches only if patt matches at a fixed offset. offset can be any
-        integer. patt will not produce captures and the peg will not advance any
-        characters. }}
+    @tr{@td{@code`(look offset ?patt)` }
+        @td{ If patt is provided, matches only if patt matches at a fixed
+        offset. offset can be any integer. patt will not produce captures and
+        the peg will not advance any characters. If patt is not provided,
+        matching occurs as if the call had been (look 0 offset). }}
 
-    @tr{@td{@code`(> offset patt)` }
-        @td{ Alias for @code`(look offset patt)` }}
+    @tr{@td{@code`(> offset ?patt)` }
+        @td{ Alias for @code`(look offset ?patt)` }}
 
     @tr{@td{@code`(to patt)` }
         @td{ Match up to patt (but not including it). If the end of the input


### PR DESCRIPTION
This PR contains changes to the docs for the `look` peg special.

The docs do not currently appear to cover the case of `look` being called with only a single argument:

>    (look offset patt)

>    Matches only if patt matches at a fixed offset. offset can be any integer. patt will not produce captures and the peg will not advance any characters.

This PR attempts to cover this additional case.

Please see [here](https://github.com/janet-lang/janet/issues/1465) for some background.