### PR TITLE
Update editors info

### DIFF
--- a/content/index.mdz
+++ b/content/index.mdz
@@ -124,17 +124,20 @@ for a more complete list. Packages in the listing can be installed via @code`jpm
     @li{@link[https://github.com/janet-lang/jhydro]{JHydro} - Cryptography for Janet}
     @li{@link[https://github.com/janet-lang/janetui]{JanetUI} - Bindings to @link[https://github.com/andlabs/libui]{libui}}}
 
-For editor support:
+## Editor Support
 
-@ul{@li{@link[https://github.com/Olical/conjure]{Conjure} - Interactive evaluation for Neovim (Clojure, Fennel, Janet)}
-    @li{@link[https://github.com/janet-lang/janet.vim]{janet.vim} - Support for Janet syntax in Vim}
-    @li{@link[https://github.com/janet-lang/vscode-janet]{vscode-janet} - VSCode plugin for Janet}
-    @li{@link[https://github.com/SerialDev/ijanet-mode]{ijanet-mode} - Emacs interactive Janet mode}
-    @li{@link[https://github.com/ALSchwalm/janet-mode]{janet-mode} - Janet major mode for Emacs}
-    @li{@link[https://github.com/velkyel/inf-janet]{inf-janet} - Inferior lisp Janet mode for Emacs}
-    @li{@link[https://atom.io/packages/language-janet]{language-janet} - Atom Editor support for Janet.}
-    @li{@link[https://github.com/archydragon/sublime-janet]{sublime-janet} - Sublime Text 3 & 4 support for Janet.}
-    @li{@link[https://github.com/pepe/janet.kak]{janet.kak} - Kakoune Editor support for Janet.}}
+Janet support exists for a number of editors.  See the links below for
+some editor-specific details.  The Zulip Instance also has an @link[https://janet.zulipchat.com/#narrow/stream/409409-editors-and-tooling]{editors and tooling}
+discussion area.
+
+@ul{@li{@link[https://github.com/sogaiu/janet-editor-and-tooling-info/blob/master/doc/neovim.md]{Neovim}}
+    @li{@link[https://github.com/sogaiu/janet-editor-and-tooling-info/blob/master/doc/vim.md]{Vim}}
+    @li{@link[https://github.com/sogaiu/janet-editor-and-tooling-info/blob/master/doc/vscode.md]{VSCode}}
+    @li{@link[https://github.com/sogaiu/janet-editor-and-tooling-info/blob/master/doc/emacs.md]{Emacs}}
+    @li{@link[https://github.com/sogaiu/janet-editor-and-tooling-info/blob/master/doc/sublime-text.md]{Sublime Text}}
+    @li{@link[https://github.com/sogaiu/janet-editor-and-tooling-info/blob/master/doc/kakoune.md]{Kakoune}}
+    @li{@link[https://github.com/sogaiu/janet-editor-and-tooling-info/blob/master/doc/tic-80.md]{TIC-80}}
+    @li{@link[https://github.com/sogaiu/janet-editor-and-tooling-info/blob/master/doc/helix.md]{Helix}}}
 
 ## Community
 


### PR DESCRIPTION
This PR is an attempt to address #222.

The initial content consists of:

* Creation of a separate editor section (broken out from being part of the "Modules and Libraries" section)
* An introductory paragraph explaining the content along with mentioning the "editors and tooling" discussion area in the Zulip Instance 
* Changing the list of currently supported editors
  * Atom has been removed because it was sunset (the link wasn't leading anywhere useful AFAICT)
  * Helix and TIC-80 were added
  * The original ordering has been mostly preserved with new things being appended to the end of the list
* Each editor link [1] points to a page at [this repository](https://github.com/sogaiu/janet-editor-and-tooling-info/).  Each such page there describes some supported features along with some relevant links.

This last change (pointing to a separate repository with descriptions) has the potential benefit of not having to update the list at janet-lang.org so frequently.

Don't know if folks are comfortable with this last point, but this is my initial proposal (^^;

---

[1] To make it easy to see those links, here they are:

* [Neovim](https://github.com/sogaiu/janet-editor-and-tooling-info/blob/master/doc/neovim.md)
* [Vim](https://github.com/sogaiu/janet-editor-and-tooling-info/blob/master/doc/vim.md)
* [VSCode](https://github.com/sogaiu/janet-editor-and-tooling-info/blob/master/doc/vscode.md)
* [Emacs](https://github.com/sogaiu/janet-editor-and-tooling-info/blob/master/doc/emacs.md)
* [Sublime Text](https://github.com/sogaiu/janet-editor-and-tooling-info/blob/master/doc/sublime-text.md)
* [Kakoune](https://github.com/sogaiu/janet-editor-and-tooling-info/blob/master/doc/kakoune.md)
* [TIC-80](https://github.com/sogaiu/janet-editor-and-tooling-info/blob/master/doc/tic-80.md)
* [Helix](https://github.com/sogaiu/janet-editor-and-tooling-info/blob/master/doc/helix.md)