### PR TITLE
Add a module page for `bundle/*`

### DIFF
--- a/content/api/bundle.mdz
+++ b/content/api/bundle.mdz
@@ -1,0 +1,11 @@
+(import ./gen-docs :as gen-docs)
+
+{:title "Bundle Module"
+ :nav-title "bundle"
+ :template "docpage.html"}
+---
+
+## Index
+
+@gen-docs/gen-prefix[bundle/]
+


### PR DESCRIPTION
This PR proposes a new page under "API" for the `bundle/*` functions.