### PR TITLE
Document that fn can be named

### DIFF
--- a/content/docs/specials.mdz
+++ b/content/docs/specials.mdz
@@ -97,6 +97,10 @@ Functions also introduce a new lexical scope, meaning the @code`def`s and
 # A function that doesn't strictly check the number of arguments.
 # Extra arguments are ignored.
 (fn [w x y z &] (tuple w w x x y y z z))
+
+# For improved debugging, name with symbol or keyword
+(fn alice [] :smile)
+(fn :bob [] :sit)
 ```
 
 For more information on functions, see the @link[/docs/functions.html][Functions


### PR DESCRIPTION
This PR is an attempt to address #223.

A couple of examples are added to the sample code for `fn` on the [Special forms page](https://janet-lang.org/1.36.0/docs/specials.html) showing that `fn` can be named via a symbol or a keyword.