### PR TITLE
Replace gitter badge with zulip one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # janet-lang.org
 
-[![Gitter](https://badges.gitter.im/janet-language/website.svg)](https://gitter.im/janet-language/website?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Zulip](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://janet.zulipchat.com)
 
 This is the source code for the website of the [Janet](https://janet-lang.org) programming
 language. It is a static website built with [mendoza](https://github.com/bakpakin/mendoza), a


### PR DESCRIPTION
As the website top page is encouraging Zulip, this PR is a suggestion to sync the chat badge in the README.

The link was determined via [these instructions](https://zulip.com/help/linking-to-zulip).

[Déjà vu](https://github.com/janet-lang/janet/pull/1510)?