### PR TITLE
Add dark theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ site
 janet_modules
 build
 /jpm/
+
+.vscode

--- a/static/css/docpage.css
+++ b/static/css/docpage.css
@@ -49,7 +49,6 @@
         padding: 5px;
         background: gray;
     }
-
 }
 
 /*
@@ -76,11 +75,11 @@
 }
 
 .toc span.selected {
-  background: #0765911a;
+    background: #0765911a;
 }
-  
+
 .toc span:hover {
-  background: #0765911a;
+    background: #0765911a;
 }
 
 .toc ul {
@@ -111,6 +110,12 @@
     color: #888;
 }
 
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+}
+
 .binding-sym {
     font-family: serif;
     font-weight: 600;
@@ -119,13 +124,25 @@
 .binding-text {
     color: #444;
     margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+    font-family: 'Dosis', 'Helvetica', sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+    .binding-text {
+        color: unset;
+    }
 }
 
 .example-title {
     margin-top: 28px;
     color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+    font-family: 'Dosis', 'Helvetica', sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+    .example-title {
+        color: #ccc;
+    }
 }
 
 /* Toc Toggle */
@@ -144,7 +161,7 @@
     height: 4px;
     width: 28px;
     border-radius: 2px;
-    background: #CCC;
+    background: #ccc;
 }
 
 #toc-toggle.open .topbar {
@@ -171,7 +188,7 @@
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+    content: '< ';
 }
 
 .next {
@@ -180,5 +197,5 @@
 }
 
 .next .prevnext-text::after {
-    content: " >";
+    content: ' >';
 }

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -62,9 +62,9 @@
 
 #replterm {
     border-radius: 2px 2px 0 0;
-    border-top: solid #CCC 1px;
-    border-left: solid #CCC 1px;
-    border-right: solid #CCC 1px;
+    border-top: solid #ccc 1px;
+    border-left: solid #ccc 1px;
+    border-right: solid #ccc 1px;
     font-family: 'Inconsolata', monospace;
     padding: 10px;
     height: 350px;
@@ -74,14 +74,30 @@
     overflow-y: auto;
 }
 
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+}
+
 #replinbar {
     border-radius: 0 0 2px 2px;
-    border: solid #CCC 1px;
+    border: solid #ccc 1px;
     font-family: 'Inconsolata', monospace;
     margin: 0 10px 10px 10px;
     color: black;
     display: flex;
-    background: #F8F8F8;
+    background: #f8f8f8;
+}
+
+@media (prefers-color-scheme: dark) {
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
 }
 
 #replprompt {
@@ -99,12 +115,18 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
     outline: none;
-    background: #F0F0F0;
+    background: #f0f0f0;
+}
+
+@media (prefers-color-scheme: dark) {
+    #replin:focus {
+        background: unset;
+    }
 }
 
 #replin br {
@@ -118,8 +140,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +150,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
-@media (max-width:500px) {
+@media (max-width: 500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -301,9 +301,7 @@ code {
 
 @media (prefers-color-scheme: dark) {
     .mendoza-code {
-        padding: 0 5px;
         background: #333;
-        white-space: nowrap;
     }
 }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -16,31 +16,36 @@ article, aside, canvas, details, embed,
 figure, figcaption, footer, header, hgroup,
 menu, nav, output, ruby, section, summary,
 time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
 }
+
 article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
-	display: block;
+    display: block;
 }
+
 body {
-	line-height: 1;
+    line-height: 1;
 }
+
 blockquote, q {
-	quotes: none;
+    quotes: none;
 }
+
 blockquote:before, blockquote:after,
 q:before, q:after {
-	content: '';
-	content: none;
+    content: '';
+    content: none;
 }
+
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+    border-collapse: collapse;
+    border-spacing: 0;
 }
 
 /* Now apply relevant style */
@@ -49,7 +54,14 @@ body {
     font-size: 1rem;
     font-family: sans-serif;
     line-height: 1.4;
-    color: #222
+    color: #222;
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
 }
 
 .content-wrapper {
@@ -80,11 +92,23 @@ a {
     color: #2674d3;
 }
 
+@media (prefers-color-scheme: dark) {
+    a {
+        color: #09a5b8;
+    }
+}
+
 h1, h2, h3, h4 {
     margin-left: 15px;
     margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+    font-family: 'Dosis', 'Helvetica', sans-serif;
     color: #111;
+}
+
+@media (prefers-color-scheme: dark) {
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
 }
 
 h1 {
@@ -92,22 +116,35 @@ h1 {
     padding-top: 3rem;
     padding-bottom: 2rem;
 }
+
 h2 {
     font-size: 2rem;
     padding-top: 32px;
     padding-bottom: 24px;
 }
+
 h3 {
     color: #333;
     font-size: 1.6rem;
     padding-top: 18px;
     padding-bottom: 16px;
 }
+
 h4 {
     color: #888;
     font-size: 1rem;
     padding-top: 8px;
     padding-bottom: 10px;
+}
+
+@media (prefers-color-scheme: dark) {
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
 }
 
 @media (max-width: 700px) {
@@ -116,11 +153,13 @@ h4 {
         padding-top: 2.5rem;
         padding-bottom: 1.5rem;
     }
+
     h2 {
         font-size: 1.8rem;
         padding-top: 28px;
         padding-bottom: 20px;
     }
+
     h3 {
         font-size: 1.5rem;
         padding-top: 16px;
@@ -134,11 +173,13 @@ h4 {
         padding-top: 2rem;
         padding-bottom: 1rem;
     }
+
     h2 {
         font-size: 1.6rem;
         padding-top: 24px;
         padding-bottom: 18px;
     }
+
     h3 {
         font-size: 1.4rem;
         padding-top: 14px;
@@ -254,8 +295,16 @@ code {
 
 .mendoza-code {
     padding: 0 5px;
-    background: #EEE;
+    background: #eee;
     white-space: nowrap;
+}
+
+@media (prefers-color-scheme: dark) {
+    .mendoza-code {
+        padding: 0 5px;
+        background: #333;
+        white-space: nowrap;
+    }
 }
 
 .mendoza-codeblock {
@@ -269,22 +318,65 @@ code {
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+    color: #b5b19e;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.mdzsyn-operator {
+    color: #ae81ff;
+}
+
+.mdzsyn-number {
+    color: #ae81ff;
+}
+
+.mdzsyn-keyword {
+    color: #ff97bc;
+}
+
+.mdzsyn-string {
+    color: #e6db74;
+}
+
+.mdzsyn-identifier {
+    color: #a6e22e;
+}
+
+.mdzsyn-symbol {
+    color: #afffff;
+}
+
+.mdzsyn-coresym {
+    color: #ffbc6d;
+}
+
+.cm-s-monokai span.cm-bracket {
+    color: #f8f8f2;
+}
+
+.cm-s-monokai span.cm-tag {
+    color: #f92672;
+}
+
+.cm-s-monokai span.cm-link {
+    color: #ae81ff;
+}
+
+.cm-s-monokai span.cm-error {
+    background: #f92672;
+    color: #f8f8f0;
+}
+
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+    color: #a6e22e;
+}
+
+.cm-s-monokai .CodeMirror-activeline-background {
+    background: #373831 !important;
+}
+
 .cm-s-monokai .CodeMirror-matchingbracket {
-  text-decoration: underline;
-  color: white !important;
+    text-decoration: underline;
+    color: white !important;
 }


### PR DESCRIPTION
Hello, during my quest to learn Janet I often find myself browsing the site late at night and it's quite a strain on my eyes.
This PR minimally changes the 3 primary CSS files by adding media queries that use a dark theme when the user's OS/browser is set to dark.

In keeping with the style of the codebase, I've opted to inline colour values as opposed to using CSS variables. The majority of colours I've chosen are already present in the styling for the regular theme, save for one or two hand-picked shades of grey where necessary.

I've chosen to co-locate the media queries next to the classnames/ids that are affected. This leads to duplicated code (the same media selector) but simpler navigation.

Attached are some (very large) screenshots to give an idea of how the site looks with the changes.

![homepage](https://github.com/user-attachments/assets/4268cea4-5089-4806-ac7e-525c11b83ee7)

![docs](https://github.com/user-attachments/assets/fa888581-3ffe-41cc-8c03-277dbea0d5bf)

![api](https://github.com/user-attachments/assets/5c86ff1d-4f1f-4a7f-bba3-4c02d55e7f74)
