### PR TITLE
Adding examples to Janet api documentation.

### DIFF
--- a/examples/++.janet
+++ b/examples/++.janet
@@ -1,0 +1,3 @@
+(var a 0) # -> 0
+(set a (+ a 1)) # -> 1
+(++ a) # -> 2 (same effect as above)

--- a/examples/--.janet
+++ b/examples/--.janet
@@ -1,0 +1,3 @@
+(var x 10) # -> 10
+(set x (- x 1)) # -> 9
+(-- x) # -> 8 (same effect as above)

--- a/examples/-_62.janet
+++ b/examples/-_62.janet
@@ -1,0 +1,5 @@
+(-> {:a [1 2 3] :b [4 5 6]}
+    (get :a)
+    (sum)
+    ((fn [x y] (/ x y)) 2)) # The 6 from the sum is threaded first and binds to x, then 2 binds to y.
+# -> 3


### PR DESCRIPTION
Added an example for `++`, `--`, and `->`. Let me know if the filenames are not what they ought to be.