### PR TITLE
Add examples for `string/split`

### DIFF
--- a/examples/string_47split.janet
+++ b/examples/string_47split.janet
@@ -1,0 +1,15 @@
+# substrings split by delimiter
+(string/split "," "x,y,z") # -> @["x" "y" "z"]
+
+# delimiter not found so result has one element
+(string/split "!" "1 2 3") # -> @["1 2 3"]
+
+# start searching part-way through
+(string/split "," "a,e,i,o" 3) # -> @["a,e" "i" "o"]
+
+# limit number of results
+(string/split ";" "a;b;c;d;e" 0 3) # -> @["a" "b" "c;d;e"]
+
+# delimiter should be non-empty
+(string/split "" "word") # -> error: expected non-empty pattern
+


### PR DESCRIPTION
As part of a Janetuary activity proposed by @erichaney, here are some examples for `string/split`.

I tried to keep things simple (and horizontally "friendly") and also tried to illustrate an edge case that tripped me up recently (^^;