### PR TITLE
Make examples file naming friendlier to Windows

### DIFF
--- a/content/api/gen-docs.janet
+++ b/content/api/gen-docs.janet
@@ -11,7 +11,7 @@
     (set ret (string/replace "  " " " ret)))
   ret)
 
-(def- replacer (peg/compile ~(% (any (+ (/ '(set "/*%") ,|(string "_" (0 $))) '1)))))
+(def- replacer (peg/compile ~(% (any (+ (/ '(set "%*/:<>?") ,|(string "_" (0 $))) '1)))))
 (defn- sym-to-filename
   "Convert a symbol to a filename. Certain filenames are not allowed on various operating systems."
   [fname]


### PR DESCRIPTION
This PR is an attempt to address #244.

Please see that issue for some background.

---

If this PR is merged before https://github.com/janet-lang/janet-lang.org/pull/242, one of the files in that PR should probably have its filename changed.

The file in question is [this one](https://github.com/janet-lang/janet-lang.org/pull/242/files#diff-0c5d311e823c84570b14cdc6e4fb9444fac80719088c40b72d3cf090f7ecc1d5).  It is currently named `->.janet`, but likely a better name might end up being `-_62.janet`.