### PR TITLE
Janet Introduction: Replace (all-bindings) with (doc) for REPL

### DIFF
--- a/content/docs/index.mdz
+++ b/content/docs/index.mdz
@@ -224,10 +224,9 @@ If at any time you want to see short documentation on a binding, use the
 
 @codeblock[janet](```(doc defn) # -> Prints the documentation for "defn"```)
 
-To see a list of all global functions in the REPL, use the @code[doc] macro
-without arguments.
+To see a list of all global bindings in the REPL, use the @code[doc] macro
+without arguments to print them out.
 
 @codeblock[janet](```(doc)```)
 
-Which will print out every global binding in the Janet REPL. You can also browse
-the @link[/doc.html][core library API] on the website.
+You can also browse the @link[/doc.html][core library API] on the website.

--- a/content/docs/index.mdz
+++ b/content/docs/index.mdz
@@ -229,4 +229,6 @@ without arguments to print them out.
 
 @codeblock[janet](```(doc)```)
 
+Note: see the @code[all-bindings] function for related functionality.
+
 You can also browse the @link[/doc.html][core library API] on the website.

--- a/content/docs/index.mdz
+++ b/content/docs/index.mdz
@@ -224,9 +224,10 @@ If at any time you want to see short documentation on a binding, use the
 
 @codeblock[janet](```(doc defn) # -> Prints the documentation for "defn"```)
 
-To see a list of all global functions in the REPL, type the command
+To see a list of all global functions in the REPL, use the @code[doc] macro
+without arguments.
 
-@codeblock[janet](```(all-bindings)```)
+@codeblock[janet](```(doc)```)
 
 Which will print out every global binding in the Janet REPL. You can also browse
 the @link[/doc.html][core library API] on the website.


### PR DESCRIPTION
I'm running Janet version `1.37.1-homebrew`.

See the introduction page at <https://janet-lang.org/docs/index.html>:

![image](https://github.com/user-attachments/assets/d194d879-a988-4196-8da9-a9b4848611fb)

`(all-bindings)` does not 'print out' all global functions when executed in the REPL, rather it returns them.

```
$ janet
Janet 1.37.1-homebrew linux/x64/gcc - '(doc)' for help
repl:1:> (all-bindings)
@[% %= * ... yield zero? zipcoll]
repl:2:>
```

This is already alluded to in the welcome message of the REPL, and the README of `janet-lang/janet`:

> To get a list of all bindings in the default environment, use the (all-bindings) function. You can also use the (doc) macro with no arguments if you are in the REPL to show bound symbols.

The `(doc)` macro does print out all global functions when executed in the REPL:

```
$ janet
Janet 1.37.1-homebrew linux/x64/gcc - '(doc)' for help
repl:1:> (doc)


    Bindings:

    % %= * *= *args* *current-file* *debug* *defdyn-prefix* *doc-color*
    *doc-width* *err* *err-color* *executable* *exit* *exit-value*
    *ffi-context* *lint-error* *lint-levels* *lint-warn* *macro-form*
[output truncated by author]
```

Tiny nitpick, but may save other beginners a bit of confusion. 

Thanks for a great doc website for a great language!