### PR TITLE
Add examples for `short-fn`

### DIFF
--- a/examples/short-fn.janet
+++ b/examples/short-fn.janet
@@ -1,0 +1,19 @@
+# a function that doubles its arguments
+((fn [n] (+ n n)) 10) # -> 20
+((short-fn (+ $ $)) 10) # -> 20
+
+# pipe reader macro offers terser expression
+(|(+ $ $) 10) # -> 20
+
+# $0 is also the first (zero-th) argument
+(|(+ $0 $0) 10) # -> 20
+
+# handling multiple arguments: $0, $1, ...
+(|(string $0 $1) "hi" "ho") # -> "hiho"
+
+# variadic function
+(|(apply + $&) 1 2 3) # -> 6
+
+# structs and some other things work too
+(|{:a 1}) # -> {:a 1}
+


### PR DESCRIPTION
Here are some examples for `short-fn`, including demonstration of the pipe reader macro: `|`.

If this gets merged, perhaps we can consider trimming the existing docstring [1] of `short-fn` of [its examples](https://github.com/janet-lang/janet/blob/2b49903c828c8667cbbbda4c5f4404d3bd3e7af1/src/boot/boot.janet#L2352-L2358) [2].

---

[1] Sort of along the lines of [this commit](https://github.com/janet-lang/janet/commit/5de889419ff26b710b706958bf99e180d084f564).

[2] Similar ones have been included in this PR.
