### PR TITLE
Swap an example for keep

### DIFF
--- a/examples/keep.janet
+++ b/examples/keep.janet
@@ -1,8 +1,9 @@
+# returns an array of truthy results of predicate
+(keep identity [false :x nil true]) # -> @[:x true]
+
 # keep values > 1, equivalent to filter
 (keep (fn [x] (when (> x 1) x)) @[0 1 2 3]) # -> @[2 3]
 
 # for all members > 2, keep the square
 (keep (fn [x] (when (> x 2) (* x x))) [0 1 3 4 5]) # -> @[9 16 25]
 
-# operates on values in table
-(keep (fn [x] (when (> x 1) (* x x))) @{:foo 1 :bar 2 :baz 3}) # -> @[4 9]


### PR DESCRIPTION
This PR swaps an example of `keep`.

The removal of one example is motivated by some comments starting [here](https://github.com/janet-lang/janet-lang.org/pull/258#issuecomment-2595925367).

Motivation for the additional example includes the points:

1. Use of a symbol in the predicate argument position that represents a pre-existing function instead of using a function constructed via the use of `fn` (as there are already examples of the latter)
2. Showing a use of `keep` which is in some sense about as simple as things might get