### PR TITLE
Mention new scopes for if and while

### DIFF
--- a/content/docs/specials.mdz
+++ b/content/docs/specials.mdz
@@ -155,6 +155,9 @@ macro.
 The condition is considered false only if it evaluates to @code`nil` or
 @code`false` - all other values are considered @code`true`.
 
+If when-true or when-false is evaluated, this is done in the context
+of a newly introduced lexical scope.
+
 @codeblock[janet]```
 (if true 10) # evaluates to 10
 (if false 10) # evaluates to nil
@@ -210,6 +213,8 @@ of the form will be continuously evaluated until the condition is @code`false`
 or @code`nil`. Therefore, it is expected that the body will contain some side
 effects or the loop will go on forever. The @code`while` loop always evaluates
 to @code`nil`.
+
+Note that the @code`while` special form introduces a new lexical scope.
 
 @codeblock[janet]```
 (var i 0)


### PR DESCRIPTION
In a [Zulip discussion about the `if` special form](https://janet.zulipchat.com/#narrow/channel/409517-help/topic/Scope.20within.20'if'.20special.20form), it came up that the [Special Forms page](https://janet-lang.org/1.37.1/docs/specials.html) doesn't appear to mention that `if` and `while` can introduce new lexical scopes (though the coverage for `do` and `fn` touch on the topic).

This PR suggests the addition of some text to remedy the situation.