### PR TITLE
Expose example filename creation via script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,34 @@ documentation tool, but of course is written in and is a dialect of Janet. See
 
 ## Adding Examples
 
-Simply add a file with the name of the binding you are giving examples for to the examples
-directory, with the `.janet` suffix. If the binding includes the `/` character, replace it with
-an underscore - this works because no bindings in the core use an underscore. For example, the
-binding `array/new` has examples in the `examples/array_new.janet` file.
+Simply add a file with the name of the binding you are giving examples
+for to the `examples` directory, with the `.janet` suffix.
 
-If such a file already exists, you can simply append your example code the existing file.
+To cope with some of Janet's symbols having names with characters that
+are not-so-friendly to certain filesystem and/or operating system
+combinations, an escaping scheme is used.
 
-When building the site, the new examples will be included in the generated documentation. Make
-sure that your example has correct janet syntax, as syntax errors will cause the entire site
-to not build. If the example has valid syntax (has a 0 exit code when loaded with
-        `janet -k example/my-fn.janet`), there may be a bug in the mendoza janet syntax
-highlighter and you open a bug in mendoza.
+For a given symbol, use the `content/api/examples.janet` script to
+generate an appropriate filename.  For example, for `array/new`,
+invoking:
+
+```
+$ janet content/api/examples.janet array/new
+```
+
+should give the output:
+
+```
+array_47new.janet
+```
+
+If such a file already exists, you can simply append your example code
+to the existing file.
+
+When building the site, the new examples will be included in the
+generated documentation. Make sure that your example has correct janet
+syntax, as syntax errors will cause the entire site to not build. If
+the example has valid syntax (has a 0 exit code when loaded with
+`janet -k example/my-fn.janet`), there may be a bug in the mendoza
+janet syntax highlighter in which case please open a bug in mendoza.
+

--- a/content/api/examples.janet
+++ b/content/api/examples.janet
@@ -1,0 +1,20 @@
+(def replacer
+  (peg/compile
+    ~(% (any (+ (/ '(set "%*/:<>?")
+                   ,|(string "_" (0 $))) '1)))))
+
+(defn sym-to-filename
+  ``
+  Convert a symbol to a filename. Certain filenames are not allowed on
+  various operating systems.
+  ``
+  [fname]
+  (string "examples/" ((peg/match replacer fname) 0) ".janet"))
+
+(defn main
+  [& args]
+  (def symbol-name (get args 1))
+  (assert symbol-name "please specify a symbol name")
+  (print (string/slice (sym-to-filename symbol-name)
+                       (length "examples/"))))
+

--- a/content/api/gen-docs.janet
+++ b/content/api/gen-docs.janet
@@ -1,6 +1,7 @@
 # Generate documentation
 
 (import mendoza/markup-env :as mdz)
+(import ./examples :as ex)
 
 (defn- remove-extra-spaces
   "Many docstrings have extra spaces that don't look
@@ -11,17 +12,11 @@
     (set ret (string/replace "  " " " ret)))
   ret)
 
-(def- replacer (peg/compile ~(% (any (+ (/ '(set "%*/:<>?") ,|(string "_" (0 $))) '1)))))
-(defn- sym-to-filename
-  "Convert a symbol to a filename. Certain filenames are not allowed on various operating systems."
-  [fname]
-  (string "examples/" ((peg/match replacer fname) 0) ".janet"))
-
 (defn- check-example
   "Check if a binding has related examples. If so, load them
   and get their content."
   [sym]
-  (def path (sym-to-filename sym))
+  (def path (ex/sym-to-filename sym))
   (when (= :file (os/stat path :mode))
     (def src (slurp path))
     src))


### PR DESCRIPTION
For background and motivation, please see [this comment](https://github.com/janet-lang/janet-lang.org/issues/256#issuecomment-2600807625).

This PR is a suggestion to address #256 by:

1. Exposing the ability to generate a suitable examples directory filename for a Janet symbol via a script
2. Updating the "Adding Examples" section of the README to explain how to use the script

As part of point 1 above, a portion of `content/api/gen-docs.janet` was relocated to a new file named `content/api/examples.janet`.  This latter file also contains a `main` entry point for use from the command line.

Use of the new script is also described in the udpated README, but a concrete invocation example is:

```
$ janet content/api/examples.janet array/new
```

which should yield the output:

```
array_47new.janet
```