### PR TITLE
Tweak def- example

### DIFF
--- a/examples/def-.janet
+++ b/examples/def-.janet
@@ -9,4 +9,4 @@ module/private-thing # -> Unknown symbol
 module/public-thing # -> :exposed
 
 # Same as normal def with :private metadata
-(def :private x private-thing :encapsulated)
+(def private-thing :private :encapsulated)


### PR DESCRIPTION
This PR suggests tweaking the last example for `def-`.

The existing example didn't work as-is for the current version of janet (though may be it did when the example was added) so an attempt was made to get it to work based on an interpretation of the associated comment.

Original:

```janet
# Same as normal def with :private metadata
(def :private x private-thing :encapsulated)
```

Suggested change:

```janet
# Same as normal def with :private metadata
(def private-thing :private :encapsulated)
```