### PR TITLE
Tweak slice examples

### DIFF
--- a/examples/slice.janet
+++ b/examples/slice.janet
@@ -1,10 +1,10 @@
-(slice @[1 2 3]) # -> (1 2 3) (a new array!)
+(slice @[1 2 3]) # -> (1 2 3)
 (slice @[:a :b :c] 1) # -> (:b :c)
 (slice [:a :b :c :d :e] 2 4) # -> (:c :d)
-(slice [:a :b :d :d :e] 2 -1) # -> (:c :d :e)
-(slice [:a :b :d :d :e] 2 -2) # -> (:c :d)
-(slice [:a :b :d :d :e] 2 -4) # -> ()
-(slice [:a :b :d :d :e] 2 -10) # -> error: range error
+(slice [:a :b :c :d :e] 2 -1) # -> (:c :d :e)
+(slice [:a :b :c :d :e] 2 -2) # -> (:c :d)
+(slice [:a :b :c :d :e] 2 -4) # -> ()
+(slice [:a :b :c :d :e] 2 -10) # -> error: end index -10 out of range [-6,5]
 (slice "abcdefg" 0 2) # -> "ab"
 (slice @"abcdefg" 0 2) # -> "ab"
 


### PR DESCRIPTION
This PR suggests tweaking some of the examples for `slice`.

The comment for the first example mentioned "a new array", but the return value is a tuple.  Since the input to `slice` is an array in this case, it seemed reasonable to remove the comment.

A number of the other examples used `[:a :b :d :d :e]` (note that there are two instances of `:d`) as an argument to `slice`, but based on the surrounding information, I suspect the intent was to use `[:a :b :c :d :e]` so this was altered in some cases.

Finally, I think error messages have changed since the original example was created so an update was made along those lines.