### PR TITLE
Tweak reverse examples

### DIFF
--- a/examples/reverse.janet
+++ b/examples/reverse.janet
@@ -1,4 +1,3 @@
 (reverse [1 2 3]) # -> @[3 2 1]
-(reverse "abcdef") # -> @[102 101 100 99 98 97]
-(reverse :abc) # -> @[99 98 97]
+(reverse "abcdef") # -> @"fedcba"
 


### PR DESCRIPTION
This PR suggests tweaking some of the examples for `reverse`.

The return value for the second example did not match recent behavior for janet so this was updated.

The third example was removed because the current docstring does not specify a behavior for operating on keywords:

> Reverses the order of the elements in a given array or tuple and returns a new array. If a string or buffer is provided, returns a buffer instead.