### PR TITLE
Suggest (doc) instead of all-bindings

### DIFF
--- a/content/index.mdz
+++ b/content/index.mdz
@@ -75,7 +75,7 @@ A REPL is launched when the @code`janet` binary is invoked with no arguments. Pa
 to display the usage information. Individual scripts can be run with @code`janet myscript.janet`
 
 If you are looking to explore, you can print a list of all available macros, functions, and constants
-by entering the command @code[all-bindings] into the REPL.
+by entering the command @code[(doc)] into the REPL.
 
 @codeblock(```
 $ janet


### PR DESCRIPTION
This PR is an attempt to address the point made in [this comment](https://github.com/janet-lang/janet-lang.org/pull/248#issuecomment-2615559963).

The suggested change in this PR is to mention `(doc)` instead of `all-bindings` in the text.  Two positive points about this are:

1. Currently, use of `all-bindings` (with parens) may lead to truncated results in a default janet installation:

    ```
    $ janet
    Janet 1.37.1-fa75a395 linux/x64/gcc - '(doc)' for help
    repl:1:> (all-bindings)
    @[% %= * ... yield zero? zipcoll]
    ```
    
    In contrast, `(doc)` gives nicer grouped output that isn't truncated and this seems more suitable for the situation in question.

2. The surrounding parens for the `(doc)` option might make it more likely that a newcomer might meet success sooner compared to `all-bindings` (which one might forget or neglect to put the parens around if one were to follow the current text literally without much thought).
