### PR TITLE
Global dark mode

### DIFF
--- a/static/1.10.1/css/docpage.css
+++ b/static/1.10.1/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,85 +88,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.10.1/css/docpage.css
+++ b/static/1.10.1/css/docpage.css
@@ -169,3 +169,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.10.1/css/docpage.css
+++ b/static/1.10.1/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,84 +87,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.10.1/css/landing.css
+++ b/static/1.10.1/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.10.1/css/landing.css
+++ b/static/1.10.1/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.10.1/css/main.css
+++ b/static/1.10.1/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #111;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #111;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #f92672;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #9effff;
-}
-.mdzsyn-coresym {
-  color: #fd971f;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #f92672;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #9effff;}
+.mdzsyn-coresym {color: #fd971f;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.10.1/css/main.css
+++ b/static/1.10.1/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #111;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #111;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #f92672;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #9effff;}
-.mdzsyn-coresym {color: #fd971f;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #f92672;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #9effff;
+}
+.mdzsyn-coresym {
+  color: #fd971f;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.10.1/css/main.css
+++ b/static/1.10.1/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.11.1/css/docpage.css
+++ b/static/1.11.1/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,85 +88,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.11.1/css/docpage.css
+++ b/static/1.11.1/css/docpage.css
@@ -169,3 +169,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.11.1/css/docpage.css
+++ b/static/1.11.1/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,84 +87,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.11.1/css/landing.css
+++ b/static/1.11.1/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.11.1/css/landing.css
+++ b/static/1.11.1/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.11.1/css/main.css
+++ b/static/1.11.1/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #111;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #111;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #f92672;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #9effff;
-}
-.mdzsyn-coresym {
-  color: #fd971f;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #f92672;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #9effff;}
+.mdzsyn-coresym {color: #fd971f;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.11.1/css/main.css
+++ b/static/1.11.1/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #111;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #111;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #f92672;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #9effff;}
-.mdzsyn-coresym {color: #fd971f;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #f92672;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #9effff;
+}
+.mdzsyn-coresym {
+  color: #fd971f;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.11.1/css/main.css
+++ b/static/1.11.1/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.12.2/css/docpage.css
+++ b/static/1.12.2/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,85 +88,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.12.2/css/docpage.css
+++ b/static/1.12.2/css/docpage.css
@@ -169,3 +169,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.12.2/css/docpage.css
+++ b/static/1.12.2/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,84 +87,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.12.2/css/landing.css
+++ b/static/1.12.2/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.12.2/css/landing.css
+++ b/static/1.12.2/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.12.2/css/main.css
+++ b/static/1.12.2/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.12.2/css/main.css
+++ b/static/1.12.2/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.12.2/css/main.css
+++ b/static/1.12.2/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.13.1/css/docpage.css
+++ b/static/1.13.1/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,85 +88,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.13.1/css/docpage.css
+++ b/static/1.13.1/css/docpage.css
@@ -169,3 +169,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.13.1/css/docpage.css
+++ b/static/1.13.1/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,84 +87,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.13.1/css/landing.css
+++ b/static/1.13.1/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.13.1/css/landing.css
+++ b/static/1.13.1/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.13.1/css/main.css
+++ b/static/1.13.1/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.13.1/css/main.css
+++ b/static/1.13.1/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.13.1/css/main.css
+++ b/static/1.13.1/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.15.0/css/docpage.css
+++ b/static/1.15.0/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,85 +88,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.15.0/css/docpage.css
+++ b/static/1.15.0/css/docpage.css
@@ -169,3 +169,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.15.0/css/docpage.css
+++ b/static/1.15.0/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,84 +87,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.15.0/css/landing.css
+++ b/static/1.15.0/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.15.0/css/landing.css
+++ b/static/1.15.0/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.15.0/css/main.css
+++ b/static/1.15.0/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.15.0/css/main.css
+++ b/static/1.15.0/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.15.0/css/main.css
+++ b/static/1.15.0/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.16.1/css/docpage.css
+++ b/static/1.16.1/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,85 +88,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.16.1/css/docpage.css
+++ b/static/1.16.1/css/docpage.css
@@ -169,3 +169,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.16.1/css/docpage.css
+++ b/static/1.16.1/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,84 +87,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.16.1/css/landing.css
+++ b/static/1.16.1/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.16.1/css/landing.css
+++ b/static/1.16.1/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.16.1/css/main.css
+++ b/static/1.16.1/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.16.1/css/main.css
+++ b/static/1.16.1/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.16.1/css/main.css
+++ b/static/1.16.1/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.17.1/css/docpage.css
+++ b/static/1.17.1/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,85 +88,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.17.1/css/docpage.css
+++ b/static/1.17.1/css/docpage.css
@@ -169,3 +169,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.17.1/css/docpage.css
+++ b/static/1.17.1/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,84 +87,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.17.1/css/landing.css
+++ b/static/1.17.1/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.17.1/css/landing.css
+++ b/static/1.17.1/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.17.1/css/main.css
+++ b/static/1.17.1/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.17.1/css/main.css
+++ b/static/1.17.1/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.17.1/css/main.css
+++ b/static/1.17.1/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.18.1/css/docpage.css
+++ b/static/1.18.1/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,85 +88,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.18.1/css/docpage.css
+++ b/static/1.18.1/css/docpage.css
@@ -169,3 +169,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.18.1/css/docpage.css
+++ b/static/1.18.1/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,84 +87,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.18.1/css/landing.css
+++ b/static/1.18.1/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.18.1/css/landing.css
+++ b/static/1.18.1/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.18.1/css/main.css
+++ b/static/1.18.1/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.18.1/css/main.css
+++ b/static/1.18.1/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.18.1/css/main.css
+++ b/static/1.18.1/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.19.0/css/docpage.css
+++ b/static/1.19.0/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,85 +88,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.19.0/css/docpage.css
+++ b/static/1.19.0/css/docpage.css
@@ -169,3 +169,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.19.0/css/docpage.css
+++ b/static/1.19.0/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,84 +87,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.19.0/css/landing.css
+++ b/static/1.19.0/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.19.0/css/landing.css
+++ b/static/1.19.0/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.19.0/css/main.css
+++ b/static/1.19.0/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.19.0/css/main.css
+++ b/static/1.19.0/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.19.0/css/main.css
+++ b/static/1.19.0/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.20.0/css/docpage.css
+++ b/static/1.20.0/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,85 +88,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.20.0/css/docpage.css
+++ b/static/1.20.0/css/docpage.css
@@ -169,3 +169,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.20.0/css/docpage.css
+++ b/static/1.20.0/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,84 +87,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.20.0/css/landing.css
+++ b/static/1.20.0/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.20.0/css/landing.css
+++ b/static/1.20.0/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.20.0/css/main.css
+++ b/static/1.20.0/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.20.0/css/main.css
+++ b/static/1.20.0/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.20.0/css/main.css
+++ b/static/1.20.0/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.21.0/css/docpage.css
+++ b/static/1.21.0/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,85 +88,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.21.0/css/docpage.css
+++ b/static/1.21.0/css/docpage.css
@@ -169,3 +169,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.21.0/css/docpage.css
+++ b/static/1.21.0/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,84 +87,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.21.0/css/landing.css
+++ b/static/1.21.0/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.21.0/css/landing.css
+++ b/static/1.21.0/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.21.0/css/main.css
+++ b/static/1.21.0/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.21.0/css/main.css
+++ b/static/1.21.0/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.21.0/css/main.css
+++ b/static/1.21.0/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.22.0/css/docpage.css
+++ b/static/1.22.0/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,85 +88,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.22.0/css/docpage.css
+++ b/static/1.22.0/css/docpage.css
@@ -169,3 +169,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.22.0/css/docpage.css
+++ b/static/1.22.0/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,84 +87,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.22.0/css/landing.css
+++ b/static/1.22.0/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.22.0/css/landing.css
+++ b/static/1.22.0/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.22.0/css/main.css
+++ b/static/1.22.0/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 0 5px;
-    background: #EEE;
+  padding: 0 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.22.0/css/main.css
+++ b/static/1.22.0/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.22.0/css/main.css
+++ b/static/1.22.0/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 0 5px;
-  background: #eee;
+    padding: 0 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.23.0/css/docpage.css
+++ b/static/1.23.0/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,85 +88,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.23.0/css/docpage.css
+++ b/static/1.23.0/css/docpage.css
@@ -169,3 +169,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.23.0/css/docpage.css
+++ b/static/1.23.0/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,84 +87,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.23.0/css/landing.css
+++ b/static/1.23.0/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.23.0/css/landing.css
+++ b/static/1.23.0/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.23.0/css/main.css
+++ b/static/1.23.0/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 0 5px;
-    background: #EEE;
+  padding: 0 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.23.0/css/main.css
+++ b/static/1.23.0/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.23.0/css/main.css
+++ b/static/1.23.0/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 0 5px;
-  background: #eee;
+    padding: 0 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.24.0/css/docpage.css
+++ b/static/1.24.0/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,85 +88,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.24.0/css/docpage.css
+++ b/static/1.24.0/css/docpage.css
@@ -169,3 +169,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.24.0/css/docpage.css
+++ b/static/1.24.0/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,84 +87,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.24.0/css/landing.css
+++ b/static/1.24.0/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.24.0/css/landing.css
+++ b/static/1.24.0/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.24.0/css/main.css
+++ b/static/1.24.0/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 0 5px;
-    background: #EEE;
+  padding: 0 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.24.0/css/main.css
+++ b/static/1.24.0/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.24.0/css/main.css
+++ b/static/1.24.0/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 0 5px;
-  background: #eee;
+    padding: 0 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.25.1/css/docpage.css
+++ b/static/1.25.1/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,85 +88,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.25.1/css/docpage.css
+++ b/static/1.25.1/css/docpage.css
@@ -169,3 +169,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.25.1/css/docpage.css
+++ b/static/1.25.1/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,84 +87,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.25.1/css/landing.css
+++ b/static/1.25.1/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.25.1/css/landing.css
+++ b/static/1.25.1/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.25.1/css/main.css
+++ b/static/1.25.1/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 0 5px;
-    background: #EEE;
+  padding: 0 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.25.1/css/main.css
+++ b/static/1.25.1/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.25.1/css/main.css
+++ b/static/1.25.1/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 0 5px;
-  background: #eee;
+    padding: 0 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.26.0/css/docpage.css
+++ b/static/1.26.0/css/docpage.css
@@ -3,53 +3,52 @@
  */
 
 .search-bar {
-    height: 40px;
-    position: absolute;
-    top: 8px;
-    right: 8px;
+  height: 40px;
+  position: absolute;
+  top: 8px;
+  right: 8px;
 }
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
-    .main-content {
-        margin-top: 35px;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
+  .main-content {
+    margin-top: 35px;
+  }
 }
 
 @media (max-width: 1400px) {
-    .main-content {
-        margin-top: 75px;
-    }
+  .main-content {
+    margin-top: 75px;
+  }
 }
 
 @media (max-width: 800px) {
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -57,43 +56,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -101,84 +100,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.26.0/css/docpage.css
+++ b/static/1.26.0/css/docpage.css
@@ -3,52 +3,53 @@
  */
 
 .search-bar {
-  height: 40px;
-  position: absolute;
-  top: 8px;
-  right: 8px;
+    height: 40px;
+    position: absolute;
+    top: 8px;
+    right: 8px;
 }
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
-  .main-content {
-    margin-top: 35px;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
+    .main-content {
+        margin-top: 35px;
+    }
 }
 
 @media (max-width: 1400px) {
-  .main-content {
-    margin-top: 75px;
-  }
+    .main-content {
+        margin-top: 75px;
+    }
 }
 
 @media (max-width: 800px) {
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -56,43 +57,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -100,85 +101,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.26.0/css/docpage.css
+++ b/static/1.26.0/css/docpage.css
@@ -182,3 +182,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.26.0/css/landing.css
+++ b/static/1.26.0/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.26.0/css/landing.css
+++ b/static/1.26.0/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.26.0/css/main.css
+++ b/static/1.26.0/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 0 5px;
-    background: #EEE;
+  padding: 0 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.26.0/css/main.css
+++ b/static/1.26.0/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.26.0/css/main.css
+++ b/static/1.26.0/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 0 5px;
-  background: #eee;
+    padding: 0 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.27.0/css/docpage.css
+++ b/static/1.27.0/css/docpage.css
@@ -3,53 +3,52 @@
  */
 
 .search-bar {
-    height: 40px;
-    position: absolute;
-    top: 8px;
-    right: 8px;
+  height: 40px;
+  position: absolute;
+  top: 8px;
+  right: 8px;
 }
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
-    .main-content {
-        margin-top: 35px;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
+  .main-content {
+    margin-top: 35px;
+  }
 }
 
 @media (max-width: 1400px) {
-    .main-content {
-        margin-top: 75px;
-    }
+  .main-content {
+    margin-top: 75px;
+  }
 }
 
 @media (max-width: 800px) {
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -57,43 +56,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -101,84 +100,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.27.0/css/docpage.css
+++ b/static/1.27.0/css/docpage.css
@@ -3,52 +3,53 @@
  */
 
 .search-bar {
-  height: 40px;
-  position: absolute;
-  top: 8px;
-  right: 8px;
+    height: 40px;
+    position: absolute;
+    top: 8px;
+    right: 8px;
 }
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
-  .main-content {
-    margin-top: 35px;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
+    .main-content {
+        margin-top: 35px;
+    }
 }
 
 @media (max-width: 1400px) {
-  .main-content {
-    margin-top: 75px;
-  }
+    .main-content {
+        margin-top: 75px;
+    }
 }
 
 @media (max-width: 800px) {
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -56,43 +57,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -100,85 +101,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.27.0/css/docpage.css
+++ b/static/1.27.0/css/docpage.css
@@ -182,3 +182,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.27.0/css/landing.css
+++ b/static/1.27.0/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.27.0/css/landing.css
+++ b/static/1.27.0/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.27.0/css/main.css
+++ b/static/1.27.0/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 0 5px;
-    background: #EEE;
+  padding: 0 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.27.0/css/main.css
+++ b/static/1.27.0/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.27.0/css/main.css
+++ b/static/1.27.0/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 0 5px;
-  background: #eee;
+    padding: 0 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.28.0/css/docpage.css
+++ b/static/1.28.0/css/docpage.css
@@ -3,53 +3,52 @@
  */
 
 .search-bar {
-    height: 40px;
-    position: absolute;
-    top: 8px;
-    right: 8px;
+  height: 40px;
+  position: absolute;
+  top: 8px;
+  right: 8px;
 }
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
-    .main-content {
-        margin-top: 35px;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
+  .main-content {
+    margin-top: 35px;
+  }
 }
 
 @media (max-width: 1400px) {
-    .main-content {
-        margin-top: 75px;
-    }
+  .main-content {
+    margin-top: 75px;
+  }
 }
 
 @media (max-width: 800px) {
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -57,43 +56,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -101,84 +100,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.28.0/css/docpage.css
+++ b/static/1.28.0/css/docpage.css
@@ -3,52 +3,53 @@
  */
 
 .search-bar {
-  height: 40px;
-  position: absolute;
-  top: 8px;
-  right: 8px;
+    height: 40px;
+    position: absolute;
+    top: 8px;
+    right: 8px;
 }
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
-  .main-content {
-    margin-top: 35px;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
+    .main-content {
+        margin-top: 35px;
+    }
 }
 
 @media (max-width: 1400px) {
-  .main-content {
-    margin-top: 75px;
-  }
+    .main-content {
+        margin-top: 75px;
+    }
 }
 
 @media (max-width: 800px) {
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -56,43 +57,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -100,85 +101,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.28.0/css/docpage.css
+++ b/static/1.28.0/css/docpage.css
@@ -182,3 +182,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.28.0/css/landing.css
+++ b/static/1.28.0/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.28.0/css/landing.css
+++ b/static/1.28.0/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.28.0/css/main.css
+++ b/static/1.28.0/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 0 5px;
-    background: #EEE;
+  padding: 0 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.28.0/css/main.css
+++ b/static/1.28.0/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.28.0/css/main.css
+++ b/static/1.28.0/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 0 5px;
-  background: #eee;
+    padding: 0 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.29.1/css/docpage.css
+++ b/static/1.29.1/css/docpage.css
@@ -3,53 +3,52 @@
  */
 
 .search-bar {
-    height: 40px;
-    position: absolute;
-    top: 8px;
-    right: 8px;
+  height: 40px;
+  position: absolute;
+  top: 8px;
+  right: 8px;
 }
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
-    .main-content {
-        margin-top: 35px;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
+  .main-content {
+    margin-top: 35px;
+  }
 }
 
 @media (max-width: 1400px) {
-    .main-content {
-        margin-top: 75px;
-    }
+  .main-content {
+    margin-top: 75px;
+  }
 }
 
 @media (max-width: 800px) {
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -57,43 +56,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -101,84 +100,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.29.1/css/docpage.css
+++ b/static/1.29.1/css/docpage.css
@@ -3,52 +3,53 @@
  */
 
 .search-bar {
-  height: 40px;
-  position: absolute;
-  top: 8px;
-  right: 8px;
+    height: 40px;
+    position: absolute;
+    top: 8px;
+    right: 8px;
 }
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
-  .main-content {
-    margin-top: 35px;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
+    .main-content {
+        margin-top: 35px;
+    }
 }
 
 @media (max-width: 1400px) {
-  .main-content {
-    margin-top: 75px;
-  }
+    .main-content {
+        margin-top: 75px;
+    }
 }
 
 @media (max-width: 800px) {
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -56,43 +57,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -100,85 +101,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.29.1/css/docpage.css
+++ b/static/1.29.1/css/docpage.css
@@ -182,3 +182,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.29.1/css/landing.css
+++ b/static/1.29.1/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.29.1/css/landing.css
+++ b/static/1.29.1/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.29.1/css/main.css
+++ b/static/1.29.1/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 0 5px;
-    background: #EEE;
+  padding: 0 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.29.1/css/main.css
+++ b/static/1.29.1/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.29.1/css/main.css
+++ b/static/1.29.1/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 0 5px;
-  background: #eee;
+    padding: 0 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.3.1/css/docpage.css
+++ b/static/1.3.1/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,79 +88,78 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.3.1/css/docpage.css
+++ b/static/1.3.1/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,78 +87,79 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.3.1/css/docpage.css
+++ b/static/1.3.1/css/docpage.css
@@ -163,3 +163,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.3.1/css/landing.css
+++ b/static/1.3.1/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.3.1/css/landing.css
+++ b/static/1.3.1/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.3.1/css/main.css
+++ b/static/1.3.1/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #111;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #111;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #f92672;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #9effff;
-}
-.mdzsyn-coresym {
-  color: #fd971f;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #f92672;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #9effff;}
+.mdzsyn-coresym {color: #fd971f;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.3.1/css/main.css
+++ b/static/1.3.1/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #111;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #111;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #f92672;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #9effff;}
-.mdzsyn-coresym {color: #fd971f;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #f92672;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #9effff;
+}
+.mdzsyn-coresym {
+  color: #fd971f;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.3.1/css/main.css
+++ b/static/1.3.1/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.31.0/css/docpage.css
+++ b/static/1.31.0/css/docpage.css
@@ -3,53 +3,52 @@
  */
 
 .search-bar {
-    height: 40px;
-    position: absolute;
-    top: 8px;
-    right: 8px;
+  height: 40px;
+  position: absolute;
+  top: 8px;
+  right: 8px;
 }
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
-    .main-content {
-        margin-top: 35px;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
+  .main-content {
+    margin-top: 35px;
+  }
 }
 
 @media (max-width: 1400px) {
-    .main-content {
-        margin-top: 75px;
-    }
+  .main-content {
+    margin-top: 75px;
+  }
 }
 
 @media (max-width: 800px) {
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -57,43 +56,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -101,84 +100,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.31.0/css/docpage.css
+++ b/static/1.31.0/css/docpage.css
@@ -3,52 +3,53 @@
  */
 
 .search-bar {
-  height: 40px;
-  position: absolute;
-  top: 8px;
-  right: 8px;
+    height: 40px;
+    position: absolute;
+    top: 8px;
+    right: 8px;
 }
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
-  .main-content {
-    margin-top: 35px;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
+    .main-content {
+        margin-top: 35px;
+    }
 }
 
 @media (max-width: 1400px) {
-  .main-content {
-    margin-top: 75px;
-  }
+    .main-content {
+        margin-top: 75px;
+    }
 }
 
 @media (max-width: 800px) {
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -56,43 +57,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -100,85 +101,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.31.0/css/docpage.css
+++ b/static/1.31.0/css/docpage.css
@@ -182,3 +182,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.31.0/css/landing.css
+++ b/static/1.31.0/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.31.0/css/landing.css
+++ b/static/1.31.0/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.31.0/css/main.css
+++ b/static/1.31.0/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 0 5px;
-    background: #EEE;
+  padding: 0 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.31.0/css/main.css
+++ b/static/1.31.0/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.31.0/css/main.css
+++ b/static/1.31.0/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 0 5px;
-  background: #eee;
+    padding: 0 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.34.0/css/docpage.css
+++ b/static/1.34.0/css/docpage.css
@@ -3,53 +3,52 @@
  */
 
 .search-bar {
-    height: 40px;
-    position: absolute;
-    top: 8px;
-    right: 8px;
+  height: 40px;
+  position: absolute;
+  top: 8px;
+  right: 8px;
 }
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
-    .main-content {
-        margin-top: 35px;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
+  .main-content {
+    margin-top: 35px;
+  }
 }
 
 @media (max-width: 1400px) {
-    .main-content {
-        margin-top: 75px;
-    }
+  .main-content {
+    margin-top: 75px;
+  }
 }
 
 @media (max-width: 800px) {
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -57,43 +56,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -101,84 +100,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.34.0/css/docpage.css
+++ b/static/1.34.0/css/docpage.css
@@ -3,52 +3,53 @@
  */
 
 .search-bar {
-  height: 40px;
-  position: absolute;
-  top: 8px;
-  right: 8px;
+    height: 40px;
+    position: absolute;
+    top: 8px;
+    right: 8px;
 }
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
-  .main-content {
-    margin-top: 35px;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
+    .main-content {
+        margin-top: 35px;
+    }
 }
 
 @media (max-width: 1400px) {
-  .main-content {
-    margin-top: 75px;
-  }
+    .main-content {
+        margin-top: 75px;
+    }
 }
 
 @media (max-width: 800px) {
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -56,43 +57,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -100,85 +101,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.34.0/css/docpage.css
+++ b/static/1.34.0/css/docpage.css
@@ -182,3 +182,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.34.0/css/landing.css
+++ b/static/1.34.0/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.34.0/css/landing.css
+++ b/static/1.34.0/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.34.0/css/main.css
+++ b/static/1.34.0/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,119 +201,89 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 0 5px;
-  background: #eee;
-  white-space: nowrap;
+    padding: 0 5px;
+    background: #EEE;
+    white-space: nowrap;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.34.0/css/main.css
+++ b/static/1.34.0/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,89 +287,119 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 0 5px;
-    background: #EEE;
-    white-space: nowrap;
+  padding: 0 5px;
+  background: #eee;
+  white-space: nowrap;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.34.0/css/main.css
+++ b/static/1.34.0/css/main.css
@@ -288,3 +288,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.35.0/css/docpage.css
+++ b/static/1.35.0/css/docpage.css
@@ -3,53 +3,52 @@
  */
 
 .search-bar {
-    height: 40px;
-    position: absolute;
-    top: 8px;
-    right: 8px;
+  height: 40px;
+  position: absolute;
+  top: 8px;
+  right: 8px;
 }
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
-    .main-content {
-        margin-top: 35px;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
+  .main-content {
+    margin-top: 35px;
+  }
 }
 
 @media (max-width: 1400px) {
-    .main-content {
-        margin-top: 75px;
-    }
+  .main-content {
+    margin-top: 75px;
+  }
 }
 
 @media (max-width: 800px) {
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -57,43 +56,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -101,84 +100,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.35.0/css/docpage.css
+++ b/static/1.35.0/css/docpage.css
@@ -3,52 +3,53 @@
  */
 
 .search-bar {
-  height: 40px;
-  position: absolute;
-  top: 8px;
-  right: 8px;
+    height: 40px;
+    position: absolute;
+    top: 8px;
+    right: 8px;
 }
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
-  .main-content {
-    margin-top: 35px;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
+    .main-content {
+        margin-top: 35px;
+    }
 }
 
 @media (max-width: 1400px) {
-  .main-content {
-    margin-top: 75px;
-  }
+    .main-content {
+        margin-top: 75px;
+    }
 }
 
 @media (max-width: 800px) {
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -56,43 +57,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -100,85 +101,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.35.0/css/docpage.css
+++ b/static/1.35.0/css/docpage.css
@@ -182,3 +182,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.35.0/css/landing.css
+++ b/static/1.35.0/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.35.0/css/landing.css
+++ b/static/1.35.0/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.35.0/css/main.css
+++ b/static/1.35.0/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,119 +201,89 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 0 5px;
-  background: #eee;
-  white-space: nowrap;
+    padding: 0 5px;
+    background: #EEE;
+    white-space: nowrap;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.35.0/css/main.css
+++ b/static/1.35.0/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,89 +287,119 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 0 5px;
-    background: #EEE;
-    white-space: nowrap;
+  padding: 0 5px;
+  background: #eee;
+  white-space: nowrap;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.35.0/css/main.css
+++ b/static/1.35.0/css/main.css
@@ -288,3 +288,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.36.0/css/docpage.css
+++ b/static/1.36.0/css/docpage.css
@@ -3,53 +3,52 @@
  */
 
 .search-bar {
-    height: 40px;
-    position: absolute;
-    top: 8px;
-    right: 8px;
+  height: 40px;
+  position: absolute;
+  top: 8px;
+  right: 8px;
 }
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
-    .main-content {
-        margin-top: 35px;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
+  .main-content {
+    margin-top: 35px;
+  }
 }
 
 @media (max-width: 1400px) {
-    .main-content {
-        margin-top: 75px;
-    }
+  .main-content {
+    margin-top: 75px;
+  }
 }
 
 @media (max-width: 800px) {
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -57,43 +56,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -101,84 +100,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.36.0/css/docpage.css
+++ b/static/1.36.0/css/docpage.css
@@ -3,52 +3,53 @@
  */
 
 .search-bar {
-  height: 40px;
-  position: absolute;
-  top: 8px;
-  right: 8px;
+    height: 40px;
+    position: absolute;
+    top: 8px;
+    right: 8px;
 }
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
-  .main-content {
-    margin-top: 35px;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
+    .main-content {
+        margin-top: 35px;
+    }
 }
 
 @media (max-width: 1400px) {
-  .main-content {
-    margin-top: 75px;
-  }
+    .main-content {
+        margin-top: 75px;
+    }
 }
 
 @media (max-width: 800px) {
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -56,43 +57,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -100,85 +101,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.36.0/css/docpage.css
+++ b/static/1.36.0/css/docpage.css
@@ -182,3 +182,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.36.0/css/landing.css
+++ b/static/1.36.0/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.36.0/css/landing.css
+++ b/static/1.36.0/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.36.0/css/main.css
+++ b/static/1.36.0/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,119 +201,89 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 0 5px;
-  background: #eee;
-  white-space: nowrap;
+    padding: 0 5px;
+    background: #EEE;
+    white-space: nowrap;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.36.0/css/main.css
+++ b/static/1.36.0/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,89 +287,119 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 0 5px;
-    background: #EEE;
-    white-space: nowrap;
+  padding: 0 5px;
+  background: #eee;
+  white-space: nowrap;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.36.0/css/main.css
+++ b/static/1.36.0/css/main.css
@@ -288,3 +288,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.37.1/css/docpage.css
+++ b/static/1.37.1/css/docpage.css
@@ -3,53 +3,52 @@
  */
 
 .search-bar {
-    height: 40px;
-    position: absolute;
-    top: 8px;
-    right: 8px;
+  height: 40px;
+  position: absolute;
+  top: 8px;
+  right: 8px;
 }
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
-    .main-content {
-        margin-top: 35px;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
+  .main-content {
+    margin-top: 35px;
+  }
 }
 
 @media (max-width: 1400px) {
-    .main-content {
-        margin-top: 75px;
-    }
+  .main-content {
+    margin-top: 75px;
+  }
 }
 
 @media (max-width: 800px) {
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -57,43 +56,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -101,84 +100,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.37.1/css/docpage.css
+++ b/static/1.37.1/css/docpage.css
@@ -3,52 +3,53 @@
  */
 
 .search-bar {
-  height: 40px;
-  position: absolute;
-  top: 8px;
-  right: 8px;
+    height: 40px;
+    position: absolute;
+    top: 8px;
+    right: 8px;
 }
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
-  .main-content {
-    margin-top: 35px;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
+    .main-content {
+        margin-top: 35px;
+    }
 }
 
 @media (max-width: 1400px) {
-  .main-content {
-    margin-top: 75px;
-  }
+    .main-content {
+        margin-top: 75px;
+    }
 }
 
 @media (max-width: 800px) {
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -56,43 +57,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -100,85 +101,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.37.1/css/docpage.css
+++ b/static/1.37.1/css/docpage.css
@@ -182,3 +182,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.37.1/css/landing.css
+++ b/static/1.37.1/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.37.1/css/landing.css
+++ b/static/1.37.1/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.37.1/css/main.css
+++ b/static/1.37.1/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,119 +201,89 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 0 5px;
-  background: #eee;
-  white-space: nowrap;
+    padding: 0 5px;
+    background: #EEE;
+    white-space: nowrap;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #ff97bc;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #afffff;
-}
-.mdzsyn-coresym {
-  color: #ffbc6d;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #ff97bc;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #afffff;}
+.mdzsyn-coresym {color: #ffbc6d;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.37.1/css/main.css
+++ b/static/1.37.1/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,89 +287,119 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 0 5px;
-    background: #EEE;
-    white-space: nowrap;
+  padding: 0 5px;
+  background: #eee;
+  white-space: nowrap;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #ff97bc;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #afffff;}
-.mdzsyn-coresym {color: #ffbc6d;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #ff97bc;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #afffff;
+}
+.mdzsyn-coresym {
+  color: #ffbc6d;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.37.1/css/main.css
+++ b/static/1.37.1/css/main.css
@@ -288,3 +288,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.4.0/css/docpage.css
+++ b/static/1.4.0/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,79 +88,78 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.4.0/css/docpage.css
+++ b/static/1.4.0/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,78 +87,79 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.4.0/css/docpage.css
+++ b/static/1.4.0/css/docpage.css
@@ -163,3 +163,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.4.0/css/landing.css
+++ b/static/1.4.0/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.4.0/css/landing.css
+++ b/static/1.4.0/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.4.0/css/main.css
+++ b/static/1.4.0/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #111;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #111;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #f92672;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #9effff;
-}
-.mdzsyn-coresym {
-  color: #fd971f;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #f92672;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #9effff;}
+.mdzsyn-coresym {color: #fd971f;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.4.0/css/main.css
+++ b/static/1.4.0/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #111;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #111;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #f92672;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #9effff;}
-.mdzsyn-coresym {color: #fd971f;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #f92672;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #9effff;
+}
+.mdzsyn-coresym {
+  color: #fd971f;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.4.0/css/main.css
+++ b/static/1.4.0/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.5.0/css/docpage.css
+++ b/static/1.5.0/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,79 +88,78 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.5.0/css/docpage.css
+++ b/static/1.5.0/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,78 +87,79 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.5.0/css/docpage.css
+++ b/static/1.5.0/css/docpage.css
@@ -163,3 +163,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.5.0/css/landing.css
+++ b/static/1.5.0/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.5.0/css/landing.css
+++ b/static/1.5.0/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.5.0/css/main.css
+++ b/static/1.5.0/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #111;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #111;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #f92672;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #9effff;
-}
-.mdzsyn-coresym {
-  color: #fd971f;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #f92672;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #9effff;}
+.mdzsyn-coresym {color: #fd971f;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.5.0/css/main.css
+++ b/static/1.5.0/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #111;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #111;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #f92672;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #9effff;}
-.mdzsyn-coresym {color: #fd971f;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #f92672;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #9effff;
+}
+.mdzsyn-coresym {
+  color: #fd971f;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.5.0/css/main.css
+++ b/static/1.5.0/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.5.1/css/docpage.css
+++ b/static/1.5.1/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,79 +88,78 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.5.1/css/docpage.css
+++ b/static/1.5.1/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,78 +87,79 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.5.1/css/docpage.css
+++ b/static/1.5.1/css/docpage.css
@@ -163,3 +163,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.5.1/css/landing.css
+++ b/static/1.5.1/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.5.1/css/landing.css
+++ b/static/1.5.1/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.5.1/css/main.css
+++ b/static/1.5.1/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #111;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #111;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #f92672;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #9effff;
-}
-.mdzsyn-coresym {
-  color: #fd971f;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #f92672;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #9effff;}
+.mdzsyn-coresym {color: #fd971f;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.5.1/css/main.css
+++ b/static/1.5.1/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #111;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #111;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #f92672;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #9effff;}
-.mdzsyn-coresym {color: #fd971f;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #f92672;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #9effff;
+}
+.mdzsyn-coresym {
+  color: #fd971f;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.5.1/css/main.css
+++ b/static/1.5.1/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.6.0/css/docpage.css
+++ b/static/1.6.0/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,79 +88,78 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.6.0/css/docpage.css
+++ b/static/1.6.0/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,78 +87,79 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.6.0/css/docpage.css
+++ b/static/1.6.0/css/docpage.css
@@ -163,3 +163,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.6.0/css/landing.css
+++ b/static/1.6.0/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.6.0/css/landing.css
+++ b/static/1.6.0/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.6.0/css/main.css
+++ b/static/1.6.0/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #111;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #111;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #f92672;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #9effff;
-}
-.mdzsyn-coresym {
-  color: #fd971f;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #f92672;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #9effff;}
+.mdzsyn-coresym {color: #fd971f;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.6.0/css/main.css
+++ b/static/1.6.0/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #111;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #111;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #f92672;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #9effff;}
-.mdzsyn-coresym {color: #fd971f;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #f92672;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #9effff;
+}
+.mdzsyn-coresym {
+  color: #fd971f;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.6.0/css/main.css
+++ b/static/1.6.0/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.7.0/css/docpage.css
+++ b/static/1.7.0/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,79 +88,78 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.7.0/css/docpage.css
+++ b/static/1.7.0/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,78 +87,79 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.7.0/css/docpage.css
+++ b/static/1.7.0/css/docpage.css
@@ -163,3 +163,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.7.0/css/landing.css
+++ b/static/1.7.0/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.7.0/css/landing.css
+++ b/static/1.7.0/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.7.0/css/main.css
+++ b/static/1.7.0/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #111;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #111;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #f92672;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #9effff;
-}
-.mdzsyn-coresym {
-  color: #fd971f;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #f92672;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #9effff;}
+.mdzsyn-coresym {color: #fd971f;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.7.0/css/main.css
+++ b/static/1.7.0/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #111;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #111;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #f92672;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #9effff;}
-.mdzsyn-coresym {color: #fd971f;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #f92672;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #9effff;
+}
+.mdzsyn-coresym {
+  color: #fd971f;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.7.0/css/main.css
+++ b/static/1.7.0/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.8.1/css/docpage.css
+++ b/static/1.8.1/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,79 +88,78 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.8.1/css/docpage.css
+++ b/static/1.8.1/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,78 +87,79 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.8.1/css/docpage.css
+++ b/static/1.8.1/css/docpage.css
@@ -163,3 +163,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.8.1/css/landing.css
+++ b/static/1.8.1/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.8.1/css/landing.css
+++ b/static/1.8.1/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.8.1/css/main.css
+++ b/static/1.8.1/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #111;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #111;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #f92672;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #9effff;
-}
-.mdzsyn-coresym {
-  color: #fd971f;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #f92672;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #9effff;}
+.mdzsyn-coresym {color: #fd971f;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.8.1/css/main.css
+++ b/static/1.8.1/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #111;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #111;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #f92672;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #9effff;}
-.mdzsyn-coresym {color: #fd971f;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #f92672;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #9effff;
+}
+.mdzsyn-coresym {
+  color: #fd971f;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.8.1/css/main.css
+++ b/static/1.8.1/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/1.9.1/css/docpage.css
+++ b/static/1.9.1/css/docpage.css
@@ -3,39 +3,40 @@
  */
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
 }
 
 @media (max-width: 800px) {
-  .main-content {
-    margin-top: 35px;
-  }
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .main-content {
+        margin-top: 35px;
+    }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
+
 }
 
 /*
@@ -43,43 +44,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-
+  
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -87,85 +88,84 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis','Helvetica', sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #CCC;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: "< ";
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: " >";
 }

--- a/static/1.9.1/css/docpage.css
+++ b/static/1.9.1/css/docpage.css
@@ -169,3 +169,17 @@
 .next .prevnext-text::after {
     content: " >";
 }
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
+}

--- a/static/1.9.1/css/docpage.css
+++ b/static/1.9.1/css/docpage.css
@@ -3,40 +3,39 @@
  */
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
 }
 
 @media (max-width: 800px) {
-    .main-content {
-        margin-top: 35px;
-    }
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
-
+  .main-content {
+    margin-top: 35px;
+  }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -44,43 +43,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
   background: #0765911a;
 }
-  
+
 .toc span:hover {
   background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -88,84 +87,85 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis','Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #CCC;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: "< ";
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: " >";
+  content: " >";
 }

--- a/static/1.9.1/css/landing.css
+++ b/static/1.9.1/css/landing.css
@@ -99,7 +99,7 @@
     margin: 0;
     width: 100%;
     transition: background 0.3s;
-    text-indent 2px;
+    text-indent: 2px;
 }
 
 #replin:focus {
@@ -118,8 +118,8 @@
 
 /* Github Banner */
 
-.github-corner:hover .octo-arm{
-    animation:octocat-wave 560ms ease-in-out;
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
@@ -128,23 +128,23 @@
     margin: 0 15px;
 }
 
-@keyframes octocat-wave{
+@keyframes octocat-wave {
     0%, 100% {
-        transform:rotate(0);
+        transform: rotate(0);
     }
     20%, 60% {
-        transform:rotate(-25deg);
+        transform: rotate(-25deg);
     }
-    40%, 80%{
-        transform:rotate(10deg);
+    40%, 80% {
+        transform: rotate(10deg);
     }
 }
 
 @media (max-width:500px) {
     .github-corner:hover .octo-arm {
-        animation:none;
+        animation: none;
     }
     .github-corner .octo-arm {
-        animation:octocat-wave 560ms ease-in-out;
+        animation: octocat-wave 560ms ease-in-out;
     }
 }

--- a/static/1.9.1/css/landing.css
+++ b/static/1.9.1/css/landing.css
@@ -148,3 +148,21 @@
         animation: octocat-wave 560ms ease-in-out;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
+    }
+}

--- a/static/1.9.1/css/main.css
+++ b/static/1.9.1/css/main.css
@@ -3,283 +3,197 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
 body {
-  line-height: 1;
+	line-height: 1;
 }
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+	quotes: none;
 }
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis','Helvetica', sans-serif;
+    color: #111;
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -287,118 +201,88 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 5px;
-  background: #eee;
+    padding: 5px;
+    background: #EEE;
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #111;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #111;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {
-  color: #b5b19e;
-}
-.mdzsyn-operator {
-  color: #ae81ff;
-}
-.mdzsyn-number {
-  color: #ae81ff;
-}
-.mdzsyn-keyword {
-  color: #f92672;
-}
-.mdzsyn-string {
-  color: #e6db74;
-}
-.mdzsyn-identifier {
-  color: #a6e22e;
-}
-.mdzsyn-symbol {
-  color: #9effff;
-}
-.mdzsyn-coresym {
-  color: #fd971f;
-}
+.mdzsyn-comment {color: #B5B19e;}
+.mdzsyn-operator {color: #ae81ff;}
+.mdzsyn-number {color: #ae81ff;}
+.mdzsyn-keyword {color: #f92672;}
+.mdzsyn-string {color: #e6db74;}
+.mdzsyn-identifier {color: #a6e22e;}
+.mdzsyn-symbol {color: #9effff;}
+.mdzsyn-coresym {color: #fd971f;}
 
-.cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-monokai span.cm-tag {
-  color: #f92672;
-}
-.cm-s-monokai span.cm-link {
-  color: #ae81ff;
-}
-.cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
-}
-.cm-s-monokai span.cm-property,
-.cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
-}
-.cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
-}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.9.1/css/main.css
+++ b/static/1.9.1/css/main.css
@@ -3,197 +3,283 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis','Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -201,88 +287,118 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 5px;
-    background: #EEE;
+  padding: 5px;
+  background: #eee;
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #111;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #111;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
-.mdzsyn-comment {color: #B5B19e;}
-.mdzsyn-operator {color: #ae81ff;}
-.mdzsyn-number {color: #ae81ff;}
-.mdzsyn-keyword {color: #f92672;}
-.mdzsyn-string {color: #e6db74;}
-.mdzsyn-identifier {color: #a6e22e;}
-.mdzsyn-symbol {color: #9effff;}
-.mdzsyn-coresym {color: #fd971f;}
+.mdzsyn-comment {
+  color: #b5b19e;
+}
+.mdzsyn-operator {
+  color: #ae81ff;
+}
+.mdzsyn-number {
+  color: #ae81ff;
+}
+.mdzsyn-keyword {
+  color: #f92672;
+}
+.mdzsyn-string {
+  color: #e6db74;
+}
+.mdzsyn-identifier {
+  color: #a6e22e;
+}
+.mdzsyn-symbol {
+  color: #9effff;
+}
+.mdzsyn-coresym {
+  color: #fd971f;
+}
 
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831 !important;
+}
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/static/1.9.1/css/main.css
+++ b/static/1.9.1/css/main.css
@@ -287,3 +287,34 @@ code {
   text-decoration: underline;
   color: white !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    table tr {
+        background: #222;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+}

--- a/static/css/docpage.css
+++ b/static/css/docpage.css
@@ -110,12 +110,6 @@
     color: #888;
 }
 
-@media (prefers-color-scheme: dark) {
-    .binding-type {
-        color: #ccc;
-    }
-}
-
 .binding-sym {
     font-family: serif;
     font-weight: 600;
@@ -127,22 +121,10 @@
     font-family: 'Dosis', 'Helvetica', sans-serif;
 }
 
-@media (prefers-color-scheme: dark) {
-    .binding-text {
-        color: unset;
-    }
-}
-
 .example-title {
     margin-top: 28px;
     color: #888;
     font-family: 'Dosis', 'Helvetica', sans-serif;
-}
-
-@media (prefers-color-scheme: dark) {
-    .example-title {
-        color: #ccc;
-    }
 }
 
 /* Toc Toggle */
@@ -198,4 +180,18 @@
 
 .next .prevnext-text::after {
     content: ' >';
+}
+
+@media (prefers-color-scheme: dark) {
+    .binding-type {
+        color: #ccc;
+    }
+
+    .binding-text {
+        color: unset;
+    }
+
+    .example-title {
+        color: #ccc;
+    }
 }

--- a/static/css/docpage.css
+++ b/static/css/docpage.css
@@ -3,52 +3,52 @@
  */
 
 .search-bar {
-    height: 40px;
-    position: absolute;
-    top: 8px;
-    right: 8px;
+  height: 40px;
+  position: absolute;
+  top: 8px;
+  right: 8px;
 }
 
 .subtitle {
-    text-align: center;
+  text-align: center;
 }
 
 .twocol {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-    .twocol {
-        display: block;
-    }
-    .toc {
-        position: absolute;
-    }
-    .main-content {
-        margin-top: 35px;
-    }
+  .twocol {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+  }
+  .main-content {
+    margin-top: 35px;
+  }
 }
 
 @media (max-width: 1400px) {
-    .main-content {
-        margin-top: 75px;
-    }
+  .main-content {
+    margin-top: 75px;
+  }
 }
 
 @media (max-width: 800px) {
-    .twocol {
-        flex-direction: column;
-    }
-    .toc {
-        background: #f2f2f2;
-        width: calc(100% - 60px);
-    }
-    .prevnext-text a {
-        padding: 5px;
-        background: gray;
-    }
+  .twocol {
+    flex-direction: column;
+  }
+  .toc {
+    background: #f2f2f2;
+    width: calc(100% - 60px);
+  }
+  .prevnext-text a {
+    padding: 5px;
+    background: gray;
+  }
 }
 
 /*
@@ -56,43 +56,43 @@
  */
 
 .toc-hidden {
-    display: none;
+  display: none;
 }
 
 .toc {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 72px;
-    padding-bottom: 45px;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 72px;
+  padding-bottom: 45px;
 }
 
 .toc a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .toc span {
-    padding: 2px;
+  padding: 2px;
 }
 
 .toc span.selected {
-    background: #0765911a;
+  background: #0765911a;
 }
 
 .toc span:hover {
-    background: #0765911a;
+  background: #0765911a;
 }
 
 .toc ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 12px;
-    margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 12px;
+  margin-right: 0px;
 }
 
 .toc ul li {
-    text-decoration: none;
-    color: #076591;
-    font-size: 1rem;
+  text-decoration: none;
+  color: #076591;
+  font-size: 1rem;
 }
 
 /* 
@@ -100,102 +100,103 @@
  */
 
 .binding {
-    margin: 10px;
-    font-size: 1rem;
+  margin: 10px;
+  font-size: 1rem;
 }
 
 .binding-type {
-    display: block;
-    font-size: 0.8em;
-    color: #888;
+  display: block;
+  font-size: 0.8em;
+  color: #888;
 }
 
 @media (prefers-color-scheme: dark) {
-    .binding-type {
-        color: #ccc;
-    }
+  .binding-type {
+    color: #ccc;
+  }
 }
 
 .binding-sym {
-    font-family: serif;
-    font-weight: 600;
+  font-family: serif;
+  font-weight: 600;
 }
 
 .binding-text {
-    color: #444;
-    margin-top: 14px;
-    font-family: 'Dosis', 'Helvetica', sans-serif;
+  color: #444;
+  margin-top: 14px;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 @media (prefers-color-scheme: dark) {
-    .binding-text {
-        color: unset;
-    }
+  .binding-text {
+    color: unset;
+  }
 }
 
 .example-title {
-    margin-top: 28px;
-    color: #888;
-    font-family: 'Dosis', 'Helvetica', sans-serif;
+  margin-top: 28px;
+  color: #888;
+  font-family: "Dosis", "Helvetica", sans-serif;
 }
 
 @media (prefers-color-scheme: dark) {
-    .example-title {
-        color: #ccc;
-    }
+  .example-title {
+    color: #ccc;
+  }
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-    text-align: center;
-    padding: 6px;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  text-align: center;
+  padding: 6px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #toc-toggle .bar {
-    margin: 7px;
-    height: 4px;
-    width: 28px;
-    border-radius: 2px;
-    background: #ccc;
+  margin: 7px;
+  height: 4px;
+  width: 28px;
+  border-radius: 2px;
+  background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-    transform: rotate(-45deg) translate(-5px, -2px);
+  transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-    transform: rotate(45deg) translate(-5px, 2px);
+  transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-    padding: 40px 15px;
-    margin: 10px 0;
+  padding: 40px 15px;
+  margin: 10px 0;
 }
 
-.prev, .next {
-    color: #076591;
+.prev,
+.next {
+  color: #076591;
 }
 
 .prev {
-    float: left;
+  float: left;
 }
 
 .prev .prevnext-text::before {
-    content: '< ';
+  content: "< ";
 }
 
 .next {
-    float: right;
-    margin-left: 30px;
+  float: right;
+  margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-    content: ' >';
+  content: " >";
 }

--- a/static/css/docpage.css
+++ b/static/css/docpage.css
@@ -3,52 +3,52 @@
  */
 
 .search-bar {
-  height: 40px;
-  position: absolute;
-  top: 8px;
-  right: 8px;
+    height: 40px;
+    position: absolute;
+    top: 8px;
+    right: 8px;
 }
 
 .subtitle {
-  text-align: center;
+    text-align: center;
 }
 
 .twocol {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: flex-start;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: flex-start;
 }
 
 @media (min-width: 1400px) {
-  .twocol {
-    display: block;
-  }
-  .toc {
-    position: absolute;
-  }
-  .main-content {
-    margin-top: 35px;
-  }
+    .twocol {
+        display: block;
+    }
+    .toc {
+        position: absolute;
+    }
+    .main-content {
+        margin-top: 35px;
+    }
 }
 
 @media (max-width: 1400px) {
-  .main-content {
-    margin-top: 75px;
-  }
+    .main-content {
+        margin-top: 75px;
+    }
 }
 
 @media (max-width: 800px) {
-  .twocol {
-    flex-direction: column;
-  }
-  .toc {
-    background: #f2f2f2;
-    width: calc(100% - 60px);
-  }
-  .prevnext-text a {
-    padding: 5px;
-    background: gray;
-  }
+    .twocol {
+        flex-direction: column;
+    }
+    .toc {
+        background: #f2f2f2;
+        width: calc(100% - 60px);
+    }
+    .prevnext-text a {
+        padding: 5px;
+        background: gray;
+    }
 }
 
 /*
@@ -56,43 +56,43 @@
  */
 
 .toc-hidden {
-  display: none;
+    display: none;
 }
 
 .toc {
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 72px;
-  padding-bottom: 45px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 72px;
+    padding-bottom: 45px;
 }
 
 .toc a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .toc span {
-  padding: 2px;
+    padding: 2px;
 }
 
 .toc span.selected {
-  background: #0765911a;
+    background: #0765911a;
 }
 
 .toc span:hover {
-  background: #0765911a;
+    background: #0765911a;
 }
 
 .toc ul {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 12px;
-  margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    margin-right: 0px;
 }
 
 .toc ul li {
-  text-decoration: none;
-  color: #076591;
-  font-size: 1rem;
+    text-decoration: none;
+    color: #076591;
+    font-size: 1rem;
 }
 
 /* 
@@ -100,103 +100,102 @@
  */
 
 .binding {
-  margin: 10px;
-  font-size: 1rem;
+    margin: 10px;
+    font-size: 1rem;
 }
 
 .binding-type {
-  display: block;
-  font-size: 0.8em;
-  color: #888;
+    display: block;
+    font-size: 0.8em;
+    color: #888;
 }
 
 @media (prefers-color-scheme: dark) {
-  .binding-type {
-    color: #ccc;
-  }
+    .binding-type {
+        color: #ccc;
+    }
 }
 
 .binding-sym {
-  font-family: serif;
-  font-weight: 600;
+    font-family: serif;
+    font-weight: 600;
 }
 
 .binding-text {
-  color: #444;
-  margin-top: 14px;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    color: #444;
+    margin-top: 14px;
+    font-family: 'Dosis', 'Helvetica', sans-serif;
 }
 
 @media (prefers-color-scheme: dark) {
-  .binding-text {
-    color: unset;
-  }
+    .binding-text {
+        color: unset;
+    }
 }
 
 .example-title {
-  margin-top: 28px;
-  color: #888;
-  font-family: "Dosis", "Helvetica", sans-serif;
+    margin-top: 28px;
+    color: #888;
+    font-family: 'Dosis', 'Helvetica', sans-serif;
 }
 
 @media (prefers-color-scheme: dark) {
-  .example-title {
-    color: #ccc;
-  }
+    .example-title {
+        color: #ccc;
+    }
 }
 
 /* Toc Toggle */
 
 #toc-toggle {
-  text-align: center;
-  padding: 6px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 2;
+    text-align: center;
+    padding: 6px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
 }
 
 #toc-toggle .bar {
-  margin: 7px;
-  height: 4px;
-  width: 28px;
-  border-radius: 2px;
-  background: #ccc;
+    margin: 7px;
+    height: 4px;
+    width: 28px;
+    border-radius: 2px;
+    background: #ccc;
 }
 
 #toc-toggle.open .topbar {
-  transform: rotate(-45deg) translate(-5px, -2px);
+    transform: rotate(-45deg) translate(-5px, -2px);
 }
 
 #toc-toggle.open .botbar {
-  transform: rotate(45deg) translate(-5px, 2px);
+    transform: rotate(45deg) translate(-5px, 2px);
 }
 
 /* Prev Next bar */
 
 .prevnext-bar {
-  padding: 40px 15px;
-  margin: 10px 0;
+    padding: 40px 15px;
+    margin: 10px 0;
 }
 
-.prev,
-.next {
-  color: #076591;
+.prev, .next {
+    color: #076591;
 }
 
 .prev {
-  float: left;
+    float: left;
 }
 
 .prev .prevnext-text::before {
-  content: "< ";
+    content: '< ';
 }
 
 .next {
-  float: right;
-  margin-left: 30px;
+    float: right;
+    margin-left: 30px;
 }
 
 .next .prevnext-text::after {
-  content: " >";
+    content: ' >';
 }

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -1,175 +1,172 @@
 /* Top Title Section */
 
 .top {
-  background: linear-gradient(to left, #09a5b8, #076591);
+    background: linear-gradient(to left, #09a5b8, #076591);
 }
 
 .title {
-  color: white;
-  margin-left: 3rem;
+    color: white;
+    margin-left: 3rem;
 }
 
 .top-under {
-  height: 2px;
-  margin-top: 2px;
-  margin-bottom: 48px;
-  background: linear-gradient(to left, #09a5b8, #076591);
+    height: 2px;
+    margin-top: 2px;
+    margin-bottom: 48px;
+    background: linear-gradient(to left, #09a5b8, #076591);
 }
 
 .block {
-  display: flex;
-  align-items: center;
-  color: white;
-  padding-top: 22px;
-  padding-bottom: 32px;
-  margin: 0 10px 0 10px;
+    display: flex;
+    align-items: center;
+    color: white;
+    padding-top: 22px;
+    padding-bottom: 32px;
+    margin: 0 10px 0 10px;
 }
 
 .block img {
-  padding: 10px;
+    padding: 10px;
 }
 
 .block p {
-  text-align: justify;
+    text-align: justify;
 }
 
 @media (max-width: 600px) {
-  .block {
-    flex-direction: column;
-    padding-bottom: 0;
-  }
+    .block {
+        flex-direction: column;
+        padding-bottom: 0;
+    }
 
-  .top-under {
-    margin-bottom: 0;
-  }
+    .top-under {
+        margin-bottom: 0;
+    }
 
-  .block p {
-    margin-top: 20px;
-  }
+    .block p {
+        margin-top: 20px;
+    }
 }
 
 #logo {
-  width: 150%;
-  max-width: 256px;
-  height: auto;
+    width: 150%;
+    max-width: 256px;
+    height: auto;
 }
 
 /* Web REPL */
 
 #replblock {
-  margin-bottom: 40px;
+    margin-bottom: 40px;
 }
 
 #replterm {
-  border-radius: 2px 2px 0 0;
-  border-top: solid #ccc 1px;
-  border-left: solid #ccc 1px;
-  border-right: solid #ccc 1px;
-  font-family: "Inconsolata", monospace;
-  padding: 10px;
-  height: 350px;
-  margin: 10px 10px 0 10px;
-  color: black;
-  overflow-x: hidden;
-  overflow-y: auto;
+    border-radius: 2px 2px 0 0;
+    border-top: solid #ccc 1px;
+    border-left: solid #ccc 1px;
+    border-right: solid #ccc 1px;
+    font-family: 'Inconsolata', monospace;
+    padding: 10px;
+    height: 350px;
+    margin: 10px 10px 0 10px;
+    color: black;
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 
 @media (prefers-color-scheme: dark) {
-  #replterm {
-    border-color: #333;
-    background: #333;
-    color: #ccc;
-  }
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
 }
 
 #replinbar {
-  border-radius: 0 0 2px 2px;
-  border: solid #ccc 1px;
-  font-family: "Inconsolata", monospace;
-  margin: 0 10px 10px 10px;
-  color: black;
-  display: flex;
-  background: #f8f8f8;
+    border-radius: 0 0 2px 2px;
+    border: solid #ccc 1px;
+    font-family: 'Inconsolata', monospace;
+    margin: 0 10px 10px 10px;
+    color: black;
+    display: flex;
+    background: #f8f8f8;
 }
 
 @media (prefers-color-scheme: dark) {
-  #replinbar {
-    border-color: #333;
-    color: unset;
-    background: #1a1a1a;
-  }
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
 }
 
 #replprompt {
-  padding: 10px;
-  display: inline-block;
-  margin: 0;
-  color: #9198e5;
-  flex-shrink: 0;
+    padding: 10px;
+    display: inline-block;
+    margin: 0;
+    color: #9198e5;
+    flex-shrink: 0;
 }
 
 #replin {
-  padding: 10px;
-  white-space: nowrap;
-  overflow: hidden;
-  margin: 0;
-  width: 100%;
-  transition: background 0.3s;
-  text-indent: 2px;
+    padding: 10px;
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0;
+    width: 100%;
+    transition: background 0.3s;
+    text-indent: 2px;
 }
 
 #replin:focus {
-  outline: none;
-  background: #f0f0f0;
+    outline: none;
+    background: #f0f0f0;
 }
 
 @media (prefers-color-scheme: dark) {
-  #replin:focus {
-    background: unset;
-  }
+    #replin:focus {
+        background: unset;
+    }
 }
 
 #replin br {
-  display: none;
+    display: none;
 }
 
 #replin * {
-  display: inline;
-  white-space: nowrap;
+    display: inline;
+    white-space: nowrap;
 }
 
 /* Github Banner */
 
 .github-corner:hover .octo-arm {
-  animation: octocat-wave 560ms ease-in-out;
+    animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
 
 .donate-link {
-  margin: 0 15px;
+    margin: 0 15px;
 }
 
 @keyframes octocat-wave {
-  0%,
-  100% {
-    transform: rotate(0);
-  }
-  20%,
-  60% {
-    transform: rotate(-25deg);
-  }
-  40%,
-  80% {
-    transform: rotate(10deg);
-  }
+    0%, 100% {
+        transform: rotate(0);
+    }
+    20%, 60% {
+        transform: rotate(-25deg);
+    }
+    40%, 80% {
+        transform: rotate(10deg);
+    }
 }
 
 @media (max-width: 500px) {
-  .github-corner:hover .octo-arm {
-    animation: none;
-  }
-  .github-corner .octo-arm {
-    animation: octocat-wave 560ms ease-in-out;
-  }
+    .github-corner:hover .octo-arm {
+        animation: none;
+    }
+    .github-corner .octo-arm {
+        animation: octocat-wave 560ms ease-in-out;
+    }
 }

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -74,14 +74,6 @@
     overflow-y: auto;
 }
 
-@media (prefers-color-scheme: dark) {
-    #replterm {
-        border-color: #333;
-        background: #333;
-        color: #ccc;
-    }
-}
-
 #replinbar {
     border-radius: 0 0 2px 2px;
     border: solid #ccc 1px;
@@ -90,14 +82,6 @@
     color: black;
     display: flex;
     background: #f8f8f8;
-}
-
-@media (prefers-color-scheme: dark) {
-    #replinbar {
-        border-color: #333;
-        color: unset;
-        background: #1a1a1a;
-    }
 }
 
 #replprompt {
@@ -121,12 +105,6 @@
 #replin:focus {
     outline: none;
     background: #f0f0f0;
-}
-
-@media (prefers-color-scheme: dark) {
-    #replin:focus {
-        background: unset;
-    }
 }
 
 #replin br {
@@ -168,5 +146,23 @@
     }
     .github-corner .octo-arm {
         animation: octocat-wave 560ms ease-in-out;
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    #replterm {
+        border-color: #333;
+        background: #333;
+        color: #ccc;
+    }
+
+    #replinbar {
+        border-color: #333;
+        color: unset;
+        background: #1a1a1a;
+    }
+
+    #replin:focus {
+        background: unset;
     }
 }

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -1,172 +1,175 @@
 /* Top Title Section */
 
 .top {
-    background: linear-gradient(to left, #09a5b8, #076591);
+  background: linear-gradient(to left, #09a5b8, #076591);
 }
 
 .title {
-    color: white;
-    margin-left: 3rem;
+  color: white;
+  margin-left: 3rem;
 }
 
 .top-under {
-    height: 2px;
-    margin-top: 2px;
-    margin-bottom: 48px;
-    background: linear-gradient(to left, #09a5b8, #076591);
+  height: 2px;
+  margin-top: 2px;
+  margin-bottom: 48px;
+  background: linear-gradient(to left, #09a5b8, #076591);
 }
 
 .block {
-    display: flex;
-    align-items: center;
-    color: white;
-    padding-top: 22px;
-    padding-bottom: 32px;
-    margin: 0 10px 0 10px;
+  display: flex;
+  align-items: center;
+  color: white;
+  padding-top: 22px;
+  padding-bottom: 32px;
+  margin: 0 10px 0 10px;
 }
 
 .block img {
-    padding: 10px;
+  padding: 10px;
 }
 
 .block p {
-    text-align: justify;
+  text-align: justify;
 }
 
 @media (max-width: 600px) {
-    .block {
-        flex-direction: column;
-        padding-bottom: 0;
-    }
+  .block {
+    flex-direction: column;
+    padding-bottom: 0;
+  }
 
-    .top-under {
-        margin-bottom: 0;
-    }
+  .top-under {
+    margin-bottom: 0;
+  }
 
-    .block p {
-        margin-top: 20px;
-    }
+  .block p {
+    margin-top: 20px;
+  }
 }
 
 #logo {
-    width: 150%;
-    max-width: 256px;
-    height: auto;
+  width: 150%;
+  max-width: 256px;
+  height: auto;
 }
 
 /* Web REPL */
 
 #replblock {
-    margin-bottom: 40px;
+  margin-bottom: 40px;
 }
 
 #replterm {
-    border-radius: 2px 2px 0 0;
-    border-top: solid #ccc 1px;
-    border-left: solid #ccc 1px;
-    border-right: solid #ccc 1px;
-    font-family: 'Inconsolata', monospace;
-    padding: 10px;
-    height: 350px;
-    margin: 10px 10px 0 10px;
-    color: black;
-    overflow-x: hidden;
-    overflow-y: auto;
+  border-radius: 2px 2px 0 0;
+  border-top: solid #ccc 1px;
+  border-left: solid #ccc 1px;
+  border-right: solid #ccc 1px;
+  font-family: "Inconsolata", monospace;
+  padding: 10px;
+  height: 350px;
+  margin: 10px 10px 0 10px;
+  color: black;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 @media (prefers-color-scheme: dark) {
-    #replterm {
-        border-color: #333;
-        background: #333;
-        color: #ccc;
-    }
+  #replterm {
+    border-color: #333;
+    background: #333;
+    color: #ccc;
+  }
 }
 
 #replinbar {
-    border-radius: 0 0 2px 2px;
-    border: solid #ccc 1px;
-    font-family: 'Inconsolata', monospace;
-    margin: 0 10px 10px 10px;
-    color: black;
-    display: flex;
-    background: #f8f8f8;
+  border-radius: 0 0 2px 2px;
+  border: solid #ccc 1px;
+  font-family: "Inconsolata", monospace;
+  margin: 0 10px 10px 10px;
+  color: black;
+  display: flex;
+  background: #f8f8f8;
 }
 
 @media (prefers-color-scheme: dark) {
-    #replinbar {
-        border-color: #333;
-        color: unset;
-        background: #1a1a1a;
-    }
+  #replinbar {
+    border-color: #333;
+    color: unset;
+    background: #1a1a1a;
+  }
 }
 
 #replprompt {
-    padding: 10px;
-    display: inline-block;
-    margin: 0;
-    color: #9198e5;
-    flex-shrink: 0;
+  padding: 10px;
+  display: inline-block;
+  margin: 0;
+  color: #9198e5;
+  flex-shrink: 0;
 }
 
 #replin {
-    padding: 10px;
-    white-space: nowrap;
-    overflow: hidden;
-    margin: 0;
-    width: 100%;
-    transition: background 0.3s;
-    text-indent: 2px;
+  padding: 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  margin: 0;
+  width: 100%;
+  transition: background 0.3s;
+  text-indent: 2px;
 }
 
 #replin:focus {
-    outline: none;
-    background: #f0f0f0;
+  outline: none;
+  background: #f0f0f0;
 }
 
 @media (prefers-color-scheme: dark) {
-    #replin:focus {
-        background: unset;
-    }
+  #replin:focus {
+    background: unset;
+  }
 }
 
 #replin br {
-    display: none;
+  display: none;
 }
 
 #replin * {
-    display: inline;
-    white-space: nowrap;
+  display: inline;
+  white-space: nowrap;
 }
 
 /* Github Banner */
 
 .github-corner:hover .octo-arm {
-    animation: octocat-wave 560ms ease-in-out;
+  animation: octocat-wave 560ms ease-in-out;
 }
 
 /* Donate button */
 
 .donate-link {
-    margin: 0 15px;
+  margin: 0 15px;
 }
 
 @keyframes octocat-wave {
-    0%, 100% {
-        transform: rotate(0);
-    }
-    20%, 60% {
-        transform: rotate(-25deg);
-    }
-    40%, 80% {
-        transform: rotate(10deg);
-    }
+  0%,
+  100% {
+    transform: rotate(0);
+  }
+  20%,
+  60% {
+    transform: rotate(-25deg);
+  }
+  40%,
+  80% {
+    transform: rotate(10deg);
+  }
 }
 
 @media (max-width: 500px) {
-    .github-corner:hover .octo-arm {
-        animation: none;
-    }
-    .github-corner .octo-arm {
-        animation: octocat-wave 560ms ease-in-out;
-    }
+  .github-corner:hover .octo-arm {
+    animation: none;
+  }
+  .github-corner .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
+  }
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -57,13 +57,6 @@ body {
     color: #222;
 }
 
-@media (prefers-color-scheme: dark) {
-    body {
-        background-color: #222;
-        color: #eee;
-    }
-}
-
 .content-wrapper {
     margin: 0 auto;
     max-width: 800px;
@@ -92,23 +85,11 @@ a {
     color: #2674d3;
 }
 
-@media (prefers-color-scheme: dark) {
-    a {
-        color: #09a5b8;
-    }
-}
-
 h1, h2, h3, h4 {
     margin-left: 15px;
     margin-right: 15px;
     font-family: 'Dosis', 'Helvetica', sans-serif;
     color: #111;
-}
-
-@media (prefers-color-scheme: dark) {
-    h1, h2, h3, h4 {
-        color: #f8f8f2;
-    }
 }
 
 h1 {
@@ -135,16 +116,6 @@ h4 {
     font-size: 1rem;
     padding-top: 8px;
     padding-bottom: 10px;
-}
-
-@media (prefers-color-scheme: dark) {
-    h3 {
-        color: #e3e0e0;
-    }
-
-    h4 {
-        color: #cccccc;
-    }
 }
 
 @media (max-width: 700px) {
@@ -299,12 +270,6 @@ code {
     white-space: nowrap;
 }
 
-@media (prefers-color-scheme: dark) {
-    .mendoza-code {
-        background: #333;
-    }
-}
-
 .mendoza-codeblock {
     color: white;
     padding: 14px;
@@ -377,4 +342,32 @@ code {
 .cm-s-monokai .CodeMirror-matchingbracket {
     text-decoration: underline;
     color: white !important;
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+        color: #eee;
+    }
+
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
+
+    h3 {
+        color: #e3e0e0;
+    }
+
+    h4 {
+        color: #cccccc;
+    }
+
+    a {
+        color: #09a5b8;
+    }
+
+    .mendoza-code {
+        background: #333;
+    }
+
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -3,238 +3,327 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-    margin: 0;
-    padding: 0;
-    border: 0;
-    font-size: 100%;
-    font: inherit;
-    vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
 
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-    display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 
 body {
-    line-height: 1;
+  line-height: 1;
 }
 
-blockquote, q {
-    quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
 
-blockquote:before, blockquote:after,
-q:before, q:after {
-    content: '';
-    content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 
 table {
-    border-collapse: collapse;
-    border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-    font-size: 1rem;
-    font-family: sans-serif;
-    line-height: 1.4;
-    color: #222;
+  font-size: 1rem;
+  font-family: sans-serif;
+  line-height: 1.4;
+  color: #222;
 }
 
 @media (prefers-color-scheme: dark) {
-    body {
-        background-color: #222;
-        color: #eee;
-    }
+  body {
+    background-color: #222;
+    color: #eee;
+  }
 }
 
 .content-wrapper {
-    margin: 0 auto;
-    max-width: 800px;
+  margin: 0 auto;
+  max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
-        max-width: 600px;
-    }
+  .content-wrapper {
+    max-width: 600px;
+  }
 }
 
-ol, ul {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-left: 45px;
-    margin-right: 20px;
+ol,
+ul {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  margin-left: 45px;
+  margin-right: 20px;
 }
 
 p {
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 1em;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 1em;
 }
 
 a {
-    color: #2674d3;
+  color: #2674d3;
 }
 
 @media (prefers-color-scheme: dark) {
-    a {
-        color: #09a5b8;
-    }
+  a {
+    color: #09a5b8;
+  }
 }
 
-h1, h2, h3, h4 {
-    margin-left: 15px;
-    margin-right: 15px;
-    font-family: 'Dosis', 'Helvetica', sans-serif;
-    color: #111;
+h1,
+h2,
+h3,
+h4 {
+  margin-left: 15px;
+  margin-right: 15px;
+  font-family: "Dosis", "Helvetica", sans-serif;
+  color: #111;
 }
 
 @media (prefers-color-scheme: dark) {
-    h1, h2, h3, h4 {
-        color: #f8f8f2;
-    }
+  h1,
+  h2,
+  h3,
+  h4 {
+    color: #f8f8f2;
+  }
 }
 
 h1 {
-    font-size: 3rem;
-    padding-top: 3rem;
-    padding-bottom: 2rem;
+  font-size: 3rem;
+  padding-top: 3rem;
+  padding-bottom: 2rem;
 }
 
 h2 {
-    font-size: 2rem;
-    padding-top: 32px;
-    padding-bottom: 24px;
+  font-size: 2rem;
+  padding-top: 32px;
+  padding-bottom: 24px;
 }
 
 h3 {
-    color: #333;
-    font-size: 1.6rem;
-    padding-top: 18px;
-    padding-bottom: 16px;
+  color: #333;
+  font-size: 1.6rem;
+  padding-top: 18px;
+  padding-bottom: 16px;
 }
 
 h4 {
-    color: #888;
-    font-size: 1rem;
-    padding-top: 8px;
-    padding-bottom: 10px;
+  color: #888;
+  font-size: 1rem;
+  padding-top: 8px;
+  padding-bottom: 10px;
 }
 
 @media (prefers-color-scheme: dark) {
-    h3 {
-        color: #e3e0e0;
-    }
+  h3 {
+    color: #e3e0e0;
+  }
 
-    h4 {
-        color: #cccccc;
-    }
+  h4 {
+    color: #cccccc;
+  }
 }
 
 @media (max-width: 700px) {
-    h1 {
-        font-size: 2.5rem;
-        padding-top: 2.5rem;
-        padding-bottom: 1.5rem;
-    }
+  h1 {
+    font-size: 2.5rem;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+  }
 
-    h2 {
-        font-size: 1.8rem;
-        padding-top: 28px;
-        padding-bottom: 20px;
-    }
+  h2 {
+    font-size: 1.8rem;
+    padding-top: 28px;
+    padding-bottom: 20px;
+  }
 
-    h3 {
-        font-size: 1.5rem;
-        padding-top: 16px;
-        padding-bottom: 14px;
-    }
+  h3 {
+    font-size: 1.5rem;
+    padding-top: 16px;
+    padding-bottom: 14px;
+  }
 }
 
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2rem;
-        padding-top: 2rem;
-        padding-bottom: 1rem;
-    }
+  h1 {
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
 
-    h2 {
-        font-size: 1.6rem;
-        padding-top: 24px;
-        padding-bottom: 18px;
-    }
+  h2 {
+    font-size: 1.6rem;
+    padding-top: 24px;
+    padding-bottom: 18px;
+  }
 
-    h3 {
-        font-size: 1.4rem;
-        padding-top: 14px;
-        padding-bottom: 12px;
-    }
+  h3 {
+    font-size: 1.4rem;
+    padding-top: 14px;
+    padding-bottom: 12px;
+  }
 }
 
 hr {
-    height: 2px;
-    background: linear-gradient(to left, #09a5b8, #076591);
-    border: none;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  height: 2px;
+  background: linear-gradient(to left, #09a5b8, #076591);
+  border: none;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-    width: calc(100% - 40px);
-    margin: 25px 20px;
+  width: calc(100% - 40px);
+  margin: 25px 20px;
 }
 
 table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
+  border-top: 1px solid #cccccc;
+  background-color: white;
 }
 
 table tr th {
-    font-weight: bold;
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
 table tr td {
-    border: 1px solid #cccccc;
-    text-align: left;
-    margin: 0;
-    padding: 8px 15px;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 8px 15px;
 }
 
-table tr th :first-child, table tr td :first-child {
-    margin-top: 0;
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
 }
 
-table tr th :last-child, table tr td :last-child {
-    margin-bottom: 0;
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-    table tr td {
-        padding: 8px 8px;
-    }
+  table tr td {
+    padding: 8px 8px;
+  }
 }
 
 /* Janet syntax highlighting */
@@ -242,139 +331,139 @@ table tr th :last-child, table tr td :last-child {
 /* Footer */
 
 footer {
-    margin: 32px auto;
-    margin-top: 100px;
-    text-align: center;
-    color: #888;
+  margin: 32px auto;
+  margin-top: 100px;
+  text-align: center;
+  color: #888;
 }
 
 .gentag {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 .see-problem {
-    font-size: 0.8em;
+  font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .carousel a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.4em;
-    margin: 5px 5px;
-    padding: 10px 15px;
-    background-color: #ffffff1a;
-    border-radius: 10px;
-    border: solid 1.5px white;
+  color: white;
+  text-decoration: none;
+  font-size: 1.4em;
+  margin: 5px 5px;
+  padding: 10px 15px;
+  background-color: #ffffff1a;
+  border-radius: 10px;
+  border: solid 1.5px white;
 }
 
 .carousel a:hover {
-    background-color: #ffffff30;
+  background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-    font-family: 'Inconsolata', monospace;
-    white-space: pre-wrap;
+  font-family: "Inconsolata", monospace;
+  white-space: pre-wrap;
 }
 
 code {
-    font-family: 'Inconsolata', monospace;
+  font-family: "Inconsolata", monospace;
 }
 
 .mendoza-code {
-    padding: 0 5px;
-    background: #eee;
-    white-space: nowrap;
+  padding: 0 5px;
+  background: #eee;
+  white-space: nowrap;
 }
 
 @media (prefers-color-scheme: dark) {
-    .mendoza-code {
-        background: #333;
-    }
+  .mendoza-code {
+    background: #333;
+  }
 }
 
 .mendoza-codeblock {
-    color: white;
-    padding: 14px;
-    background: #333;
-    border-radius: 5px;
-    margin: 15px;
-    line-height: 1.2;
+  color: white;
+  padding: 14px;
+  background: #333;
+  border-radius: 5px;
+  margin: 15px;
+  line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
 .mdzsyn-comment {
-    color: #b5b19e;
+  color: #b5b19e;
 }
 
 .mdzsyn-operator {
-    color: #ae81ff;
+  color: #ae81ff;
 }
 
 .mdzsyn-number {
-    color: #ae81ff;
+  color: #ae81ff;
 }
 
 .mdzsyn-keyword {
-    color: #ff97bc;
+  color: #ff97bc;
 }
 
 .mdzsyn-string {
-    color: #e6db74;
+  color: #e6db74;
 }
 
 .mdzsyn-identifier {
-    color: #a6e22e;
+  color: #a6e22e;
 }
 
 .mdzsyn-symbol {
-    color: #afffff;
+  color: #afffff;
 }
 
 .mdzsyn-coresym {
-    color: #ffbc6d;
+  color: #ffbc6d;
 }
 
 .cm-s-monokai span.cm-bracket {
-    color: #f8f8f2;
+  color: #f8f8f2;
 }
 
 .cm-s-monokai span.cm-tag {
-    color: #f92672;
+  color: #f92672;
 }
 
 .cm-s-monokai span.cm-link {
-    color: #ae81ff;
+  color: #ae81ff;
 }
 
 .cm-s-monokai span.cm-error {
-    background: #f92672;
-    color: #f8f8f0;
+  background: #f92672;
+  color: #f8f8f0;
 }
 
 .cm-s-monokai span.cm-property,
 .cm-s-monokai span.cm-attribute {
-    color: #a6e22e;
+  color: #a6e22e;
 }
 
 .cm-s-monokai .CodeMirror-activeline-background {
-    background: #373831 !important;
+  background: #373831 !important;
 }
 
 .cm-s-monokai .CodeMirror-matchingbracket {
-    text-decoration: underline;
-    color: white !important;
+  text-decoration: underline;
+  color: white !important;
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -178,12 +178,6 @@ table tr {
     background-color: white;
 }
 
-@media (prefers-color-scheme: dark) {
-    table tr {
-        background: #222;
-    }
-}
-
 table tr th {
     font-weight: bold;
     border: 1px solid #cccccc;
@@ -372,8 +366,11 @@ code {
         color: #09a5b8;
     }
 
+    table tr {
+        background: #222;
+    }
+
     .mendoza-code {
         background: #333;
     }
-
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -3,327 +3,238 @@
    License: none (public domain)
 */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
 }
 
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+    display: block;
 }
 
 body {
-  line-height: 1;
+    line-height: 1;
 }
 
-blockquote,
-q {
-  quotes: none;
+blockquote, q {
+    quotes: none;
 }
 
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
+blockquote:before, blockquote:after,
+q:before, q:after {
+    content: '';
+    content: none;
 }
 
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+    border-collapse: collapse;
+    border-spacing: 0;
 }
 
 /* Now apply relevant style */
 
 body {
-  font-size: 1rem;
-  font-family: sans-serif;
-  line-height: 1.4;
-  color: #222;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222;
 }
 
 @media (prefers-color-scheme: dark) {
-  body {
-    background-color: #222;
-    color: #eee;
-  }
+    body {
+        background-color: #222;
+        color: #eee;
+    }
 }
 
 .content-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
+    margin: 0 auto;
+    max-width: 800px;
 }
 
 @media (max-width: 1000px) {
-  .content-wrapper {
-    max-width: 600px;
-  }
+    .content-wrapper {
+        max-width: 600px;
+    }
 }
 
-ol,
-ul {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  margin-left: 45px;
-  margin-right: 20px;
+ol, ul {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 45px;
+    margin-right: 20px;
 }
 
 p {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 1em;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-bottom: 1em;
 }
 
 a {
-  color: #2674d3;
+    color: #2674d3;
 }
 
 @media (prefers-color-scheme: dark) {
-  a {
-    color: #09a5b8;
-  }
+    a {
+        color: #09a5b8;
+    }
 }
 
-h1,
-h2,
-h3,
-h4 {
-  margin-left: 15px;
-  margin-right: 15px;
-  font-family: "Dosis", "Helvetica", sans-serif;
-  color: #111;
+h1, h2, h3, h4 {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-family: 'Dosis', 'Helvetica', sans-serif;
+    color: #111;
 }
 
 @media (prefers-color-scheme: dark) {
-  h1,
-  h2,
-  h3,
-  h4 {
-    color: #f8f8f2;
-  }
+    h1, h2, h3, h4 {
+        color: #f8f8f2;
+    }
 }
 
 h1 {
-  font-size: 3rem;
-  padding-top: 3rem;
-  padding-bottom: 2rem;
+    font-size: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 
 h2 {
-  font-size: 2rem;
-  padding-top: 32px;
-  padding-bottom: 24px;
+    font-size: 2rem;
+    padding-top: 32px;
+    padding-bottom: 24px;
 }
 
 h3 {
-  color: #333;
-  font-size: 1.6rem;
-  padding-top: 18px;
-  padding-bottom: 16px;
+    color: #333;
+    font-size: 1.6rem;
+    padding-top: 18px;
+    padding-bottom: 16px;
 }
 
 h4 {
-  color: #888;
-  font-size: 1rem;
-  padding-top: 8px;
-  padding-bottom: 10px;
+    color: #888;
+    font-size: 1rem;
+    padding-top: 8px;
+    padding-bottom: 10px;
 }
 
 @media (prefers-color-scheme: dark) {
-  h3 {
-    color: #e3e0e0;
-  }
+    h3 {
+        color: #e3e0e0;
+    }
 
-  h4 {
-    color: #cccccc;
-  }
+    h4 {
+        color: #cccccc;
+    }
 }
 
 @media (max-width: 700px) {
-  h1 {
-    font-size: 2.5rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
-  }
+    h1 {
+        font-size: 2.5rem;
+        padding-top: 2.5rem;
+        padding-bottom: 1.5rem;
+    }
 
-  h2 {
-    font-size: 1.8rem;
-    padding-top: 28px;
-    padding-bottom: 20px;
-  }
+    h2 {
+        font-size: 1.8rem;
+        padding-top: 28px;
+        padding-bottom: 20px;
+    }
 
-  h3 {
-    font-size: 1.5rem;
-    padding-top: 16px;
-    padding-bottom: 14px;
-  }
+    h3 {
+        font-size: 1.5rem;
+        padding-top: 16px;
+        padding-bottom: 14px;
+    }
 }
 
 @media (max-width: 500px) {
-  h1 {
-    font-size: 2rem;
-    padding-top: 2rem;
-    padding-bottom: 1rem;
-  }
+    h1 {
+        font-size: 2rem;
+        padding-top: 2rem;
+        padding-bottom: 1rem;
+    }
 
-  h2 {
-    font-size: 1.6rem;
-    padding-top: 24px;
-    padding-bottom: 18px;
-  }
+    h2 {
+        font-size: 1.6rem;
+        padding-top: 24px;
+        padding-bottom: 18px;
+    }
 
-  h3 {
-    font-size: 1.4rem;
-    padding-top: 14px;
-    padding-bottom: 12px;
-  }
+    h3 {
+        font-size: 1.4rem;
+        padding-top: 14px;
+        padding-bottom: 12px;
+    }
 }
 
 hr {
-  height: 2px;
-  background: linear-gradient(to left, #09a5b8, #076591);
-  border: none;
-  margin-top: 30px;
-  margin-bottom: 30px;
+    height: 2px;
+    background: linear-gradient(to left, #09a5b8, #076591);
+    border: none;
+    margin-top: 30px;
+    margin-bottom: 30px;
 }
 
 /* Tables */
 
 table {
-  width: calc(100% - 40px);
-  margin: 25px 20px;
+    width: calc(100% - 40px);
+    margin: 25px 20px;
 }
 
 table tr {
-  border-top: 1px solid #cccccc;
-  background-color: white;
+    border-top: 1px solid #cccccc;
+    background-color: white;
 }
 
 table tr th {
-  font-weight: bold;
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
 table tr td {
-  border: 1px solid #cccccc;
-  text-align: left;
-  margin: 0;
-  padding: 8px 15px;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 8px 15px;
 }
 
-table tr th :first-child,
-table tr td :first-child {
-  margin-top: 0;
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
 }
 
-table tr th :last-child,
-table tr td :last-child {
-  margin-bottom: 0;
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
 }
 
 /* Small devices */
 @media (max-width: 600px) {
-  table tr td {
-    padding: 8px 8px;
-  }
+    table tr td {
+        padding: 8px 8px;
+    }
 }
 
 /* Janet syntax highlighting */
@@ -331,139 +242,139 @@ table tr td :last-child {
 /* Footer */
 
 footer {
-  margin: 32px auto;
-  margin-top: 100px;
-  text-align: center;
-  color: #888;
+    margin: 32px auto;
+    margin-top: 100px;
+    text-align: center;
+    color: #888;
 }
 
 .gentag {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .see-problem {
-  font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 /* Carousel */
 
 .carousel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  padding-bottom: 20px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .carousel a {
-  color: white;
-  text-decoration: none;
-  font-size: 1.4em;
-  margin: 5px 5px;
-  padding: 10px 15px;
-  background-color: #ffffff1a;
-  border-radius: 10px;
-  border: solid 1.5px white;
+    color: white;
+    text-decoration: none;
+    font-size: 1.4em;
+    margin: 5px 5px;
+    padding: 10px 15px;
+    background-color: #ffffff1a;
+    border-radius: 10px;
+    border: solid 1.5px white;
 }
 
 .carousel a:hover {
-  background-color: #ffffff30;
+    background-color: #ffffff30;
 }
 
 /* Syntax highlighting */
 
 pre {
-  font-family: "Inconsolata", monospace;
-  white-space: pre-wrap;
+    font-family: 'Inconsolata', monospace;
+    white-space: pre-wrap;
 }
 
 code {
-  font-family: "Inconsolata", monospace;
+    font-family: 'Inconsolata', monospace;
 }
 
 .mendoza-code {
-  padding: 0 5px;
-  background: #eee;
-  white-space: nowrap;
+    padding: 0 5px;
+    background: #eee;
+    white-space: nowrap;
 }
 
 @media (prefers-color-scheme: dark) {
-  .mendoza-code {
-    background: #333;
-  }
+    .mendoza-code {
+        background: #333;
+    }
 }
 
 .mendoza-codeblock {
-  color: white;
-  padding: 14px;
-  background: #333;
-  border-radius: 5px;
-  margin: 15px;
-  line-height: 1.2;
+    color: white;
+    padding: 14px;
+    background: #333;
+    border-radius: 5px;
+    margin: 15px;
+    line-height: 1.2;
 }
 
 /* Based on Sublime Text's Monokai theme */
 
 .mdzsyn-comment {
-  color: #b5b19e;
+    color: #b5b19e;
 }
 
 .mdzsyn-operator {
-  color: #ae81ff;
+    color: #ae81ff;
 }
 
 .mdzsyn-number {
-  color: #ae81ff;
+    color: #ae81ff;
 }
 
 .mdzsyn-keyword {
-  color: #ff97bc;
+    color: #ff97bc;
 }
 
 .mdzsyn-string {
-  color: #e6db74;
+    color: #e6db74;
 }
 
 .mdzsyn-identifier {
-  color: #a6e22e;
+    color: #a6e22e;
 }
 
 .mdzsyn-symbol {
-  color: #afffff;
+    color: #afffff;
 }
 
 .mdzsyn-coresym {
-  color: #ffbc6d;
+    color: #ffbc6d;
 }
 
 .cm-s-monokai span.cm-bracket {
-  color: #f8f8f2;
+    color: #f8f8f2;
 }
 
 .cm-s-monokai span.cm-tag {
-  color: #f92672;
+    color: #f92672;
 }
 
 .cm-s-monokai span.cm-link {
-  color: #ae81ff;
+    color: #ae81ff;
 }
 
 .cm-s-monokai span.cm-error {
-  background: #f92672;
-  color: #f8f8f0;
+    background: #f92672;
+    color: #f8f8f0;
 }
 
 .cm-s-monokai span.cm-property,
 .cm-s-monokai span.cm-attribute {
-  color: #a6e22e;
+    color: #a6e22e;
 }
 
 .cm-s-monokai .CodeMirror-activeline-background {
-  background: #373831 !important;
+    background: #373831 !important;
 }
 
 .cm-s-monokai .CodeMirror-matchingbracket {
-  text-decoration: underline;
-  color: white !important;
+    text-decoration: underline;
+    color: white !important;
 }


### PR DESCRIPTION
This PR expands on the previous dark mode work and includes a fix provided by @elfenermarcell.

There are effectively 3 changes implemented:

1. Fixes an erroneous CSS declaration for `text-indent` across all occurrences (with some minor whitespace formatting in applicable files).
2. Collapses all dark mode rules into a single media query in each `.css` file.
3. Appends the above CSS query to every `.css` file in `static` to enable dark mode across all versions of documentation.

Please note that `3.` was done by a script that simply appends a string to all `.css` files that match (`docpage.css`, `landing.css`, `main.css`). I may have overlooked something obvious when doing this due to my lack of familiarity with the build tools and project structure.