### PR TITLE
Tweak look peg special docs

### DIFF
--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -178,11 +178,10 @@ compiled to bytecode).
     @tr{@td{@code`(! patt)` }
     @td{ Alias for @code`(not patt)` }}
 
-    @tr{@td{@code`(look offset ?patt)` }
-        @td{ If patt is provided, matches only if patt matches at a fixed
-        offset. offset can be any integer. patt will not produce captures and
-        the peg will not advance any characters. If patt is not provided,
-        matching occurs as if the call had been (look 0 offset). }}
+    @tr{@td{@code`(look ?offset patt)` }
+        @td{ Matches only if patt matches at a fixed offset. offset can be
+             any integer and defaults to 0. The peg will not advance any
+             characters. }}
 
     @tr{@td{@code`(> offset ?patt)` }
         @td{ Alias for @code`(look offset ?patt)` }}


### PR DESCRIPTION
This PR contains suggested changes to the documentation for the `look` peg special and attempts to address #281.

For background please see the following issues:

* https://github.com/janet-lang/janet/issues/1554
* https://github.com/janet-lang/janet-lang.org/issues/281

The changes include:

* Addressing the point made at the top of [this comment](https://github.com/janet-lang/janet/issues/1554#issuecomment-2629749471):

    > I don't know when it was decided that lookahead should not produce captures, but in most cases they do. We should fix the docs here.

* Simplifying the form of the signature and overall text as:

    > (look ?offset patt)

    > Matches only if patt matches at a fixed offset. offset can be any integer and defaults to 0. The peg will not advance any characters.

I find the new version shorter and clearer.  I had found the previous version confusing but failed to think of a good way to improve things.  Placing the `?` before the `offset` label wasn't something that occurred to me and am grateful for that and the associated prose.

Thanks to @edsrzf for the original issue and the improved text :+1: 