### PR TITLE
Improve consistency of examples

### DIFF
--- a/examples/defn-.janet
+++ b/examples/defn-.janet
@@ -7,7 +7,7 @@
 # In a file main.janet
 (import module)
 
-(module/not-exposed-fn 10) # -> Unknown symbol error
+(module/not-exposed-fn 10) # -> compile error: unknown symbol module/not-exposed-fn
 
 # Same as
 (defn not-exposed-fn

--- a/examples/defn.janet
+++ b/examples/defn.janet
@@ -2,7 +2,8 @@
   [x]
   (print (+ x 1)))
 
-(simple 10) # -> 11
+# prints 11
+(simple 10) # -> nil
 
 (defn long-body
   [y]
@@ -22,7 +23,7 @@
   [x y z & more]
   [x y z more])
 
-(with-tags 1 2) # raises arity error
+(with-tags 1 2) # compile error: <function with-tags> expects at least 3 arguments, got 2
 (with-tags 1 2 3) # -> (1 2 3 ())
 (with-tags 1 2 3 4) # -> (1 2 3 (4))
 (with-tags 1 2 3 4 5) # -> (1 2 3 (4 5))

--- a/examples/eval-string.janet
+++ b/examples/eval-string.janet
@@ -1,4 +1,4 @@
 (eval-string "(+ 1 2 3 4)") # -> 10
-(eval-string ")") # -> parse error
-(eval-string "(bloop)") # -> compile error
-(eval-string "(+ nil nil)") # -> runtime error
+(eval-string ")") # -> error: unexpected closing delimiter )
+(eval-string "(bloop)") # -> error: unknown symbol bloop
+(eval-string "(+ nil nil)") # -> error: could not find method :+ for nil or :r+ for nil

--- a/examples/eval.janet
+++ b/examples/eval.janet
@@ -1,3 +1,3 @@
 (eval '(+ 1 2 3)) # -> 6
-(eval '(error :oops)) # -> raises error :oops
-(eval '(+ nil nil)) # -> raises error
+(eval '(error :oops)) # -> error :oops
+(eval '(+ nil nil)) # -> error: could not find method :+ for nil or :r+ for nil

--- a/examples/loop.janet
+++ b/examples/loop.janet
@@ -1,53 +1,63 @@
-# -> prints 0123456789 (not followed by newline)
+# prints 0123456789 (not followed by newline)
 (loop [x :range [0 10]]
-  (prin x))
+  (prin x)) # -> nil
 
 # Cartesian product (nested loops)
 
-# -> prints 00010203101112132021222330313233
+# prints 00010203101112132021222330313233
 # Same as (for x 0 4 (for y 0 4 (prin x y)))
 (loop [x :range [0 4]
        y :range [0 4]]
-  (prin x y))
+  (prin x y)) # -> nil
 
-# -> prints bytes of "hello, world" as numbers
+# prints bytes of "hello, world" as numbers
 (loop [character :in "hello, world"]
-  (print character))
+  (print character)) # -> nil
 
-# -> prints 1, 2, and 3, in an unspecified order
+# prints 1, 2, and 3, in an unspecified order
 (loop [value :in {:a 1 :b 2 :c 3}]
-  (print value))
+  (print value)) # -> nil
 
-# -> prints 0 to 99 inclusive
+# prints 0 to 99 inclusive
 (loop [x :in (range 100)]
-  (print x))
+  (print x)) # -> nil
 
 # Complex body
 (loop [x :in (range 10)]
   (print x)
-  (print (inc c))
-  (print (+ x 2)))
+  (print (inc x))
+  (print (+ x 2))) # -> nil
+# prints n, n+1, n+2 (for n = 0 through 9) each time through the loop
+# 0
+# 1
+# 2
+# ...
+# 9
+# 10
+# 11
 
 # Iterate over keys
 (loop [k :keys {:a 1 :b 2 :c 3}]
-  (print k))
+  (print k)) # -> nil
 # print a, b, and c in an unspecified order
 
 (loop [index :keys [:a :b :c :d]]
-  (print index))
-#  print 0, 1, 2, and 3 in order.
+  (print index)) # -> nil
+# print 0, 1, 2, and 3 in order.
 
 (defn print-pairs
   [x]
   (loop [[k v] :pairs x]
     (printf "[%v]=%v" k v)))
 
-(print-pairs [:a :b :c])
+(print-pairs [:a :b :c]) # -> nil
+# prints
 # [0]=:a
 # [1]=:b
 # [2]=:c
 
-(print-pairs {:a 1 :b 2 :c 3})
+(print-pairs {:a 1 :b 2 :c 3}) # -> nil
+# prints
 # [:a]=1
 # [:b]=2
 # [:c]=3
@@ -56,11 +66,11 @@
 # of the loop
 
 (loop [x :range [0 100] :when (even? x)]
-  (print x))
+  (print x)) # -> nil
 # prints even numbers 0, 2, 4, ..., 98
 
 (loop [x :range [1 100] :while (pos? (% x 7))]
-  (print x))
+  (print x)) # -> nil
 # prints 1, 2, 3, 4, 5, 6
 
 # Consume fibers as generators
@@ -71,15 +81,15 @@
         (yield i)))))
 
 (loop [x :in f]
-  (print x))
+  (print x)) # -> nil
 # print 0, 1, 2, ... 99
 
 # Modifiers in nested loops
-
 (loop [x :range [0 10]
       :after (print)
        y :range [0 x]]
-  (prin y " "))
+  (prin y " ")) # -> nil
+# prints
 # 0
 # 0 1
 # 0 1 2
@@ -89,3 +99,4 @@
 # 0 1 2 3 4 5 6
 # 0 1 2 3 4 5 6 7
 # 0 1 2 3 4 5 6 7 8
+


### PR DESCRIPTION
This PR is an attempt to improve the consistency of some of the existing examples.

Apart from a minor adjustment to correct an example, the changes basically are of three types:

1. Try to use the `# -> <value>` comment to describe return values only
2. Try to use the `# -> error: ...` (or `# -> compile error: ...`, etc.) comment(s) to describe errors
3. Use comments to describe printed output -- AFAICT, this is more in line with how most of the other examples do things
