### PR TITLE
Tweak examples: *, apply, and product

### DIFF
--- a/examples/_42.janet
+++ b/examples/_42.janet
@@ -1,8 +1,8 @@
 (*) # -> 1
 (* 10) # -> 10
 (* 10 20) # -> 200
-(* 1 2 3 4 5 6 7) #-> 5040
+(* 1 2 3 4 5 6 7) # -> 5040
 
 # Can take product of array with splice, but 'product' is better
-(* ;(range 1 20)) #-> 1.21645e+17
-(product (range 1 20)) #-> 1.21645e+17
+(* ;(range 1 20)) # -> 1.21645100408832e+17
+(product (range 1 20)) # -> 1.21645100408832e+17

--- a/examples/apply.janet
+++ b/examples/apply.janet
@@ -1,7 +1,7 @@
 (apply + (range 10)) # -> 45
 (apply + []) # -> 0
 (apply + 1 2 3 4 5 6 7 [8 9 10]) # -> 55
-(apply + 1 2 3 4 5 6 7 8 9 10) # -> error: expected array|tuple, got number 
+(apply + 1 2 3 4 5 6 7 8 9 10) # -> error: expected array or tuple, got 10
 
 # Can also be used to call macros like functions.
 # Will return the macro expanded code of the original macro.

--- a/examples/product.janet
+++ b/examples/product.janet
@@ -4,7 +4,7 @@
 (product (range 1 10)) # -> 362880
 
 # Product over byte values [0-255] in a string
-(product "hello") # -> 1.35996e+10
+(product "hello") # -> 13599570816
 
 # Product over values in a table or struct
 (product {:a 1 :b 2 :c 4}) # -> 8


### PR DESCRIPTION
This PR contains some minor tweaks to examples for `*`, `apply`, and `product`.

Apart from some formatting, some return values and an error message are modified.