### PR TITLE
Prevent recent text addition from being interpreted as a Janet statement

### DIFF
--- a/content/docs/index.mdz
+++ b/content/docs/index.mdz
@@ -106,7 +106,7 @@ gmake test CC=gcc
 
 @ol{@li{Install @link[https://visualstudio.microsoft.com/downloads/#visual-studio-community-2022][Visual Studio]
         or @link[https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022][Visual Studio Build Tools]
-        (you will need the latest MSVC build tools and the Windows SDK components)}
+        \(you will need the latest MSVC build tools and the Windows SDK components)}
     @li{Run a Visual Studio Command Prompt (@code`cl.exe` and @code`link.exe`
         need to be on the PATH)}
     @li{@code[cd] to the directory with Janet}


### PR DESCRIPTION
Previous commit [a334121](https://github.com/janet-lang/janet-lang.org/commit/a3341215b5a4515169df923cc2fe69de0da969b1) breaks the build on my system (and I assume for everyone else).

It appears that Mendoza is interpreting the "(you will need ..." text as a Janet statement.  This change prevents that and enables the build to complete.