### PR TITLE
Add examples for map

### DIFF
--- a/examples/map.janet
+++ b/examples/map.janet
@@ -1,0 +1,9 @@
+# inc is applied to every value of the input data structure
+(map inc [7 8 9]) # -> @[8 9 10]
+
+# multiple data structures can be handled
+(map array [:x :y] [-1 1]) # -> @[@[:x -1] @[:y 1]]
+
+# result array has length of the shortest input data structure
+(map |(pos? (+ ;$&)) [1 2 3] [-1 -2 -3] [0 1]) # -> @[false true]
+


### PR DESCRIPTION
Here are some examples for `map`, including the use of multiple input data structures.

The examples are intended to demonstrate some of what has been spelled out in the docstring for `map` which was updated in [this commit](https://github.com/janet-lang/janet/commit/363e32d4557c939c8dbcb069a0a7578b5b594daf).