### PR TITLE
Clarify meaning of $&

### DIFF
--- a/content/docs/functions.mdz
+++ b/content/docs/functions.mdz
@@ -94,7 +94,7 @@ reader macro (or the equivalent @code`short-fn` macro):
 Within the above sorts of contexts the symbol @code`$` refers to the
 first (or zero-th) argument.  Similarly, @code`$0`, @code`$1`,
 etc. refer to the arguments at index 0, 1, etc. and @code`$&` refers
-to all passed arguments as a tuple.
+to all remaining arguments as a tuple.
 
 There is a common macro @code[defn] that can be used for creating functions and
 immediately binding them to a name. @code[defn] works as expected at both the


### PR DESCRIPTION
This PR is a suggestion to clarify the meaning of `$&` as [currently expressed on the function page](https://janet-lang.org/1.38.0/docs/functions.html):

```
Similarly, $0, $1, etc. refer to the arguments at index 0, 1,
etc. and $& refers to all passed arguments as a tuple.
```

IIUC, when `$`, `$0`, ..., `$i` is/are used, `$&` refers to less than "all passed arguments":

```janet
(|[$0 $1 $&] 1 0 -1)
# =>
[1 0 [-1]]

(|[$ $&] 1 0)
# =>
[1 [0]]
```

The suggested change is to express the above as:

```
Similarly, $0, $1, etc. refer to the arguments at index 0, 1,
etc. and $& refers to all remaining arguments as a tuple.
```

i.e. saying "all remaining arguments" instead of "all passed arguments".