### PR TITLE
Sync feature list with readme

### DIFF
--- a/content/index.mdz
+++ b/content/index.mdz
@@ -29,7 +29,8 @@ such as threading, networking, an event loop, subprocess handling, regex-like li
     @li{Lexical scoping}
     @li{REPL and interactive debugger}
     @li{Parsing Expression Grammars built in to the core library}
-    @li{500+ functions and macros in the core library}
+    @li{600+ functions and macros in the core library}
+    @li{Erlang-style supervision trees that integrate with the event loop}
     @li{Export your projects to standalone executables with a companion build tool, jpm}
     @li{Add to a project with just @code`janet.c` and @code`janet.h`}}
 


### PR DESCRIPTION
The readme on Github says Janet supports more than the website does, so, so I updated the later one with two lined.

It might be an incomplete update, so there could be still some outdated info now on the website.