### PR TITLE
Use square brackets in Tuples examples

### DIFF
--- a/content/docs/syntax.mdz
+++ b/content/docs/syntax.mdz
@@ -216,7 +216,7 @@ struct.
 @codeblock[janet]```
 {}
 {:key1 "value1" :key2 :value2 :key3 3}
-{(1 2 3) (4 5 6)}
+{[1 2 3] [4 5 6]}
 {@[] @[]}
 {1 2 3 4 5 6}
 ```
@@ -229,7 +229,7 @@ indicate that they are mutable.
 @codeblock[janet]```
 @{}
 @{:key1 "value1" :key2 :value2 :key3 3}
-@{(1 2 3) (4 5 6)}
+@{[1 2 3] [4 5 6]}
 @{@[] @[]}
 @{1 2 3 4 5 6}
 ```


### PR DESCRIPTION
Two of the Struct examples at https://janet-lang.org/docs/syntax.html#Structs-1 won't work on the REPL:

```lisp
$ janet
Janet 1.38.0-ddc12295 linux/x64/gcc - '(doc)' for help
repl:1:> {(1 2 3) (4 5 6)}
repl:1:2: compile error: 1 expects 1 argument, got 2
repl:2:> {'(1 2 3) '(4 5 6)}
{(1 2 3) (4 5 6)}
```

This PR changes 2 examples to the tuple literal (square brackets) that are introduced in the Tuples section right before Structs. For newcomers it's probably simpler to use the square brackets rather than using quote (```'```) at this point in the docs (`quote` is introduced in the Special Forms section, right after Structs).