### PR TITLE
Change janetdocs.com to .org

### DIFF
--- a/content/index.mdz
+++ b/content/index.mdz
@@ -149,4 +149,4 @@ We also support @link[https://github.com/janet-lang/janet/discussions]{GitHub Di
 
 ### Janet Docs
 
-For help, you can also check out @link[https://janetdocs.com]{Janet Docs} for Janet documentation with user-provided examples. Feel free to contribute your own examples here to help fellow programmers.
+For help, you can also check out @link[https://janetdocs.org]{Janet Docs} for Janet documentation with user-provided examples. Feel free to contribute your own examples here to help fellow programmers.


### PR DESCRIPTION
https://janetdocs.org/ is actively maintained.