### PR TITLE
Change janetdocs.com to .org

### DIFF
--- a/content/api/gen-docs.janet
+++ b/content/api/gen-docs.janet
@@ -24,7 +24,8 @@
 (def- url-repl-chars
   {(chr "%") "%25"
    (chr "?") "_q"
-   (chr "=") "%3d"})
+   (chr "=") "%3d"
+   (chr "/") "%2f"})
 
 (defn jdoc-escape
   [str]
@@ -96,7 +97,7 @@
                               :content {:tag "code" :language (require "janet.syntax") :content (string example)}}] [])
                (if c-example
                  {:tag "a" "href"
-                  (string "https://janetdocs.com/" (jdoc-escape key))
+                  (string "https://janetdocs.org/core-api/" (jdoc-escape key)) # Spork will be "https://janetdocs.org/spork/", JPM .org/jpm/ etc.
                   :content "Community Examples"})]}))
 
 (defn- all-entries 

--- a/content/index.mdz
+++ b/content/index.mdz
@@ -149,4 +149,4 @@ We also support @link[https://github.com/janet-lang/janet/discussions]{GitHub Di
 
 ### Janet Docs
 
-For help, you can also check out @link[https://janetdocs.com]{Janet Docs} for Janet documentation with user-provided examples. Feel free to contribute your own examples here to help fellow programmers.
+For help, you can also check out @link[https://janetdocs.org]{Janet Docs} for Janet documentation with user-provided examples. Feel free to contribute your own examples here to help fellow programmers.


### PR DESCRIPTION
I hope these two templates cover it.

I wasn't sure whether I should change all the saved html - I was surprised by its presence in the repo instead of only templates. Swlkr said he will redirect .com to .org, so eventually the old ones will break (due to my new url scheme with package names) (deprecated bindings will break on the change, though). If you decide to change them, ctrl-f:

-  `janetdocs.com/` -> `janetdocs.org/core-api/` (note the `/`)
- `janetdocs.com"` -> `janetdocs.org"` (for indexes, note the `"`)