### PR TITLE
Tweak wording consistency in PEG docs

### DIFF
--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -213,11 +213,11 @@ compiled to bytecode).
 
     @tr{@td{@code`(sub window-patt patt)` }
         @td{ Match @code`window-patt`, and if it succeeds match
-             @code`patt` against the bytes that @code`window-patt` matched.
-             @code`patt` cannot match more than @code`window-patt`; it will
-             see end-of-input at the end of the substring matched by
-             @code`window-patt`. If @code`patt` also succeeds, @code`sub` will
-             advance to the end of what @code`window-patt` matched. }}
+             @code`patt` against the characters that @code`window-patt`
+             matched. @code`patt` cannot match more than @code`window-patt`;
+             it will see end-of-input at the end of the substring matched by
+             @code`window-patt`. If @code`patt` also succeeds, @code`sub`
+             will advance to the end of what @code`window-patt` matched. }}
 
     @tr{@td{@code`(split separator-patt patt)` }
         @td{ Split the remaining input by @code`separator-patt`, and execute


### PR DESCRIPTION
This PR is an attempt to unify the use of the word "characters" over "bytes" in the documentation for each of the PEG specials.

Although "byte(s)" is used elsewhere in the prose, none of the other documentation for the other PEG specials was using the word "bytes".

Also, the way "bytes" is used appears to only be in the context of explaining the term "character":

> A character in Janet is considered a byte, so PEGs will work on any string of bytes. No special meaning is given to the 0 byte, or the string terminator as in many languages.

This inconsistency was noted in [one of #337's  comments](https://github.com/janet-lang/janet-lang.org/issues/337#issuecomment-4358643561) during a discussion.