### PR TITLE
Add some primitive peg examples

### DIFF
--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -112,12 +112,21 @@ Primitive patterns are not that useful by themselves, but can be passed to
 @codeblock[janet]```
 (peg/match "hello" "hello") # -> @[]
 (peg/match "hello" "hi") # -> nil
+
 (peg/match 1 "hi") # -> @[]
 (peg/match 1 "") # -> nil
+(peg/match 0 "") # -> @[]
+(peg/match -1 "") # -> @[]
+
 (peg/match '(range "AZ") "F") # -> @[]
 (peg/match '(range "AZ") "-") # -> nil
+
 (peg/match '(set "AZ") "F") # -> nil
 (peg/match '(set "ABCDEFGHIJKLMNOPQRSTUVWXYZ") "F") # -> @[]
+
+(peg/match true "smile") # -> @[]
+
+(peg/match false "wink") # -> nil
 ```
 
 ## Combining patterns


### PR DESCRIPTION
This is an attempt to partially address #341.

Examples for `0`, `1`, `true`, and `false` have been added and spacing has been modified in an attempt to help with readability.