### PR TITLE
Add combining pattern peg examples

### DIFF
--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -321,6 +321,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(split "," (some (range "09"))) "1,4,9,16,25") # -> @[]
 (peg/match '(split (some " ") (any 1)) "a bee  can   do") # -> @[]
+
+(peg/match '(til ";" (some (range "ac"))) "abc_;xyz") # -> @[]
+(peg/match '(* (til ";" (some (set "ehy"))) 2 -1) "hey_;hi") # -> @[]
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -258,6 +258,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(sequence "x" 2 "y") "x!=y") # -> @[]
 (peg/match '(* 1 "a" 1 "b" 1) "{a=b}") # -> @[]
+
+(peg/match '(any "j") "") # -> @[]
+(peg/match '(any "j") "j") # -> @[]
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -315,6 +315,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(5 (range "az")) "qwerty") # -> @[]
 (peg/match '(3 (range "09")) "12x") # -> nil
+
+(peg/match '(sub (to ";") (some (range "az"))) "hello;hola") # -> @[]
+(peg/match '(* (sub (to ";") (thru -1)) ";bob") "alice;boba") # -> @[]
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -252,6 +252,11 @@ succeeds. If no sub-pattern succeeds, then the whole pattern fails. Note that
 this means that the order of @code`x y z` in choice @strong{does} matter. If
 @code`y` matches everything that @code`z` matches, @code`z` will never succeed.
 
+@codeblock[janet]```
+(peg/match '(choice "ant" "bee") "bee") # -> @[]
+(peg/match '(+ 3 0) "abcd") # -> @[]
+```
+
 ## Captures
 
 So far we have only been concerned with "does this text match this language?".

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -312,6 +312,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(? ":") "x") # -> @[]
 (peg/match '(some (* (set "xyz") (? ","))) "x,y,z") # -> @[]
+
+(peg/match '(5 (range "az")) "qwerty") # -> @[]
+(peg/match '(3 (range "09")) "12x") # -> nil
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -279,6 +279,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(if (some (set "aeiou")) 3) "aei") # -> @[]
 (peg/match '(if (some (set "aeio")) 3) "uuu") # -> nil
+
+(peg/match '(if-not (some (range "09")) 3) "abc") # -> @[]
+(peg/match '(if-not (some (range "09")) 3) "012") # -> nil
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -267,6 +267,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(between 1 3 "Z") "ZZZ") # -> @[]
 (peg/match '(between 2 3 "Z") "Z") # -> nil
+
+(peg/match '(at-least 2 "A") "AAAAH!") # -> @[]
+(peg/match '(at-least 3 "A") "AA") # -> nil
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -264,6 +264,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(some "J") "") # -> nil
 (peg/match '(some "J") "JJJ") # -> @[]
+
+(peg/match '(between 1 3 "Z") "ZZZ") # -> @[]
+(peg/match '(between 2 3 "Z") "Z") # -> nil
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -318,6 +318,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(sub (to ";") (some (range "az"))) "hello;hola") # -> @[]
 (peg/match '(* (sub (to ";") (thru -1)) ";bob") "alice;boba") # -> @[]
+
+(peg/match '(split "," (some (range "09"))) "1,4,9,16,25") # -> @[]
+(peg/match '(split (some " ") (any 1)) "a bee  can   do") # -> @[]
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -297,6 +297,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(to "!") "jump!") # -> @[]
 (peg/match '(* (to "!") "!") "jump!") # -> @[]
+
+(peg/match '(thru "?") "swim?") # -> @[]
+(peg/match '(* (thru "?") "?") "swim?") # -> nil
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -309,6 +309,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 (peg/match '(opt "s") "a") # -> @[]
 (peg/match '(* "cat" (opt "s")) "cat") # -> @[]
 (peg/match '(* "cat" (opt "s")) "cats") # -> @[]
+
+(peg/match '(? ":") "x") # -> @[]
+(peg/match '(some (* (set "xyz") (? ","))) "x,y,z") # -> @[]
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -261,6 +261,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(any "j") "") # -> @[]
 (peg/match '(any "j") "j") # -> @[]
+
+(peg/match '(some "J") "") # -> nil
+(peg/match '(some "J") "JJJ") # -> @[]
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -294,6 +294,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(> "ahead") "ahead") # -> @[]
 (peg/match '(* (> 3 "cat") "my") "my cat") # -> @[]
+
+(peg/match '(to "!") "jump!") # -> @[]
+(peg/match '(* (to "!") "!") "jump!") # -> @[]
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -288,6 +288,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(! "pegasus") "horse") # -> @[]
 (peg/match '(* (! "cat") (set "dgo")) "dog") # -> @[]
+
+(peg/match '(look 1 "b") "ab") # -> @[]
+(peg/match '(* 1 (look -1 "a")) "ab") # -> @[]
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -305,6 +305,10 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 (peg/match '(* (capture "a") (backmatch)) "aa") # -> @["a"]
 (peg/match ~(* '"a" "b" '(backmatch)) "aba") # -> @["a" "a"]
 (peg/match ~(* (capture "a" :x) "b" '(backmatch :x)) "aba") # -> @["a" "a"]
+
+(peg/match '(opt "s") "a") # -> @[]
+(peg/match '(* "cat" (opt "s")) "cat") # -> @[]
+(peg/match '(* "cat" (opt "s")) "cats") # -> @[]
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -276,6 +276,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(repeat 2 "A") "AAAAH!") # -> @[]
 (peg/match '(* (repeat 2 "A") "HH!" -1) "AAHH!") # -> @[]
+
+(peg/match '(if (some (set "aeiou")) 3) "aei") # -> @[]
+(peg/match '(if (some (set "aeio")) 3) "uuu") # -> nil
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -291,6 +291,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(look 1 "b") "ab") # -> @[]
 (peg/match '(* 1 (look -1 "a")) "ab") # -> @[]
+
+(peg/match '(> "ahead") "ahead") # -> @[]
+(peg/match '(* (> 3 "cat") "my") "my cat") # -> @[]
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -282,6 +282,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(if-not (some (range "09")) 3) "abc") # -> @[]
 (peg/match '(if-not (some (range "09")) 3) "012") # -> nil
+
+(peg/match '(not (set "XYZ")) "A") # -> @[]
+(peg/match '(* (not (set "XYZ")) 3 -1) "123") # -> @[]
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -273,6 +273,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(at-most 2 "A") "AAA") # -> @[]
 (peg/match '(* (at-most 2 "A") "B") "AAB") # -> @[]
+
+(peg/match '(repeat 2 "A") "AAAAH!") # -> @[]
+(peg/match '(* (repeat 2 "A") "HH!" -1) "AAHH!") # -> @[]
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -255,6 +255,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 @codeblock[janet]```
 (peg/match '(choice "ant" "bee") "bee") # -> @[]
 (peg/match '(+ 3 0) "abcd") # -> @[]
+
+(peg/match '(sequence "x" 2 "y") "x!=y") # -> @[]
+(peg/match '(* 1 "a" 1 "b" 1) "{a=b}") # -> @[]
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -270,6 +270,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(at-least 2 "A") "AAAAH!") # -> @[]
 (peg/match '(at-least 3 "A") "AA") # -> nil
+
+(peg/match '(at-most 2 "A") "AAA") # -> @[]
+(peg/match '(* (at-most 2 "A") "B") "AAB") # -> @[]
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -300,6 +300,11 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(thru "?") "swim?") # -> @[]
 (peg/match '(* (thru "?") "?") "swim?") # -> nil
+
+# see capturing section for `capture`, `'`, and tagging
+(peg/match '(* (capture "a") (backmatch)) "aa") # -> @["a"]
+(peg/match ~(* '"a" "b" '(backmatch)) "aba") # -> @["a" "a"]
+(peg/match ~(* (capture "a" :x) "b" '(backmatch :x)) "aba") # -> @["a" "a"]
 ```
 
 ## Captures

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -285,6 +285,9 @@ this means that the order of @code`x y z` in choice @strong{does} matter. If
 
 (peg/match '(not (set "XYZ")) "A") # -> @[]
 (peg/match '(* (not (set "XYZ")) 3 -1) "123") # -> @[]
+
+(peg/match '(! "pegasus") "horse") # -> @[]
+(peg/match '(* (! "cat") (set "dgo")) "dog") # -> @[]
 ```
 
 ## Captures


### PR DESCRIPTION
This is an attempt to partially address https://github.com/janet-lang/janet-lang.org/issues/341.

Examples for the following combining pattern PEG specials have been added:

* `choice`, `+`
* `sequence`, `*`
* `any`
* `some`
* `between`
* `at-least`
* `at-most`
* `repeat`
* `if`
* `if-not`
* `not`, `!`
* `look`, `>`
* `to`
* `thru`
* `backmatch`
* `opt`, `?`
* `n` (integer alias for `repeat`)
* `sub`
* `split`
* `til`

It seemed necessary to use capturing to demonstrate `backmatch` so a comment was added above its examples to hint at where to find out more about capturing.

**Update**: I've split things up into separate commits in the hopes that reviewing and reverting is easier.

**Update 2**: The examples should at least be "correct" as I've checked them with the script posted [here](https://github.com/janet-lang/janet-lang.org/issues/341#issuecomment-4371937255).