### PR TITLE
Add capture peg examples

### DIFF
--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -396,6 +396,14 @@ grammars simpler.
          allowed in Janet files. To tag the capture without forcing a
          particular base, use @code`(number patt nil :tag)`. }}}
 
+@codeblock[janet]```
+(peg/match '(capture "x") "xy") # -> @["x"]
+(peg/match '(<- "x") "xy") # -> @["x"]
+(peg/match ''"x" "xy") # -> @["x"]
+(peg/match ~'"x" "xy") # -> @["x"]
+(peg/match '(* 1 (capture "b")) "ab") # -> @["b"]
+```
+
 ## Grammars and recursion
 
 The feature that makes PEGs so much more powerful than pattern matching

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -420,6 +420,9 @@ grammars simpler.
 (peg/match ~(position) "run") # -> @[0]
 (peg/match ~(* (to -1) (position)) "slam dunk") # -> @[9]
 (peg/match ~(some (* ($) (to ",") 1)) "i,j,k,l,") # -> @[0 2 4 6]
+
+(peg/match ~(column) "0123") # -> @[1]
+(peg/match ~(* 2 (column)) "0123") # -> @[3]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -416,6 +416,10 @@ grammars simpler.
 (peg/match ~(constant :smile) "whatever") # -> @[:smile]
 
 (peg/match ~(argument 1) "ursula" 0 :franklin :leguin) # -> @[:leguin]
+
+(peg/match ~(position) "run") # -> @[0]
+(peg/match ~(* (to -1) (position)) "slam dunk") # -> @[9]
+(peg/match ~(some (* ($) (to ",") 1)) "i,j,k,l,") # -> @[0 2 4 6]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -445,6 +445,8 @@ grammars simpler.
 (peg/match ~(drop (capture 1)) "x") # -> @[]
 
 (peg/match ~(* (only-tags (* (<- 1 :x) 1)) (backref :x)) "xy") # -> @["x"]
+
+(peg/match ~(nth 2 (* '1 '1 '1)) "abc") # -> @["c"]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -423,6 +423,9 @@ grammars simpler.
 
 (peg/match ~(column) "0123") # -> @[1]
 (peg/match ~(* 2 (column)) "0123") # -> @[3]
+
+(peg/match ~(line) "0123") # -> @[1]
+(peg/match ~(* 2 (line)) "0\n1") # -> @[2]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -414,6 +414,8 @@ grammars simpler.
 (peg/match ~(/ (* '(to ",") 1 '(to -1)) ,|{$0 $1}) "x,y") # -> @[{"x" "y"}]
 
 (peg/match ~(constant :smile) "whatever") # -> @[:smile]
+
+(peg/match ~(argument 1) "ursula" 0 :franklin :leguin) # -> @[:leguin]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -465,6 +465,9 @@ grammars simpler.
 (peg/match '(number (range "09")) "8") # -> @[8]
 (peg/match '(number (some (range "07")) 8) "10") # -> @[8]
 (peg/match '(number (some (range "09" "AF")) 16) "FF") # -> @[255]
+
+# length obtained from top of capture stack placed there via `number`
+(peg/match ~'(lenprefix (number (range "09")) 1) "2xy") # -> @["2xy"]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -441,6 +441,8 @@ grammars simpler.
 (last (protect (peg/match ~(error 1) "a"))) # -> "match error at line 1, column 1"
 (last (protect (peg/match ~(error) ""))) # -> "match error at line 1, column 1"
 (peg/match ~(error -1) "nah") # -> nil
+
+(peg/match ~(drop (capture 1)) "x") # -> @[]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -457,6 +457,10 @@ grammars simpler.
 
 (peg/match ~(int 1) "\x80") # -> @[-128]
 (peg/match ~(int 2) "\xFF\x7F") # -> @[32767]
+
+(peg/match ~(int-be 1) "\x80") # -> @[-128]
+(peg/match ~(int-be 2) "\xFF\x7F") # -> @[-129]
+(peg/match ~(int-be 2) "\x7F\xFF") # -> @[32767]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -450,6 +450,10 @@ grammars simpler.
 
 (peg/match ~(uint 1) "a") # -> @[97]
 (peg/match ~(uint 2) "\xFF\x7F") # -> @[32767]
+
+(peg/match ~(uint-be 1) "a") # -> @[97]
+(peg/match ~(uint-be 2) "\xFF\x7F") # -> @[65407]
+(peg/match ~(uint-be 2) "\x7F\xFF") # -> @[32767]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -432,6 +432,10 @@ grammars simpler.
 
 (peg/match ~(cmt '(to -1) ,keyword) "greetings") # -> @[:greetings]
 (peg/match ~(cmt (* '1 "=" '1) ,table) "x=1") # -> @[@{"x" "1"}]
+
+(peg/match ~(* (<- 1 :x) (<- 1 :x) (-> :x)) "xy") # -> @["x" "y" "y"]
+(peg/match ~(* (<- 1 :x) (unref (<- 1 :x) :x) (-> :x)) "xy") # -> @["x" "y" "x"]
+(peg/match ~(* (<- 1 :x) (unref (<- 1 :x)) (-> :x)) "xy") # -> @["x" "y" "x"]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -405,6 +405,8 @@ grammars simpler.
 
 (peg/match '(* (capture "a" :x) 1 (backref :x)) "a;b") # -> @["a" "a"]
 (peg/match '(* (<- "a" :y) (-> :y)) "a;b") # -> @["a" "a"]
+
+(peg/match '(group (* '1 '1 '1)) "abc") # -> @[@["a" "b" "c"]]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -436,6 +436,11 @@ grammars simpler.
 (peg/match ~(* (<- 1 :x) (<- 1 :x) (-> :x)) "xy") # -> @["x" "y" "y"]
 (peg/match ~(* (<- 1 :x) (unref (<- 1 :x) :x) (-> :x)) "xy") # -> @["x" "y" "x"]
 (peg/match ~(* (<- 1 :x) (unref (<- 1 :x)) (-> :x)) "xy") # -> @["x" "y" "x"]
+
+(last (protect (peg/match ~(error (* 1 '1 '1)) "abc"))) # -> "c"
+(last (protect (peg/match ~(error 1) "a"))) # -> "match error at line 1, column 1"
+(last (protect (peg/match ~(error) ""))) # -> "match error at line 1, column 1"
+(peg/match ~(error -1) "nah") # -> nil
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -407,6 +407,11 @@ grammars simpler.
 (peg/match '(* (<- "a" :y) (-> :y)) "a;b") # -> @["a" "a"]
 
 (peg/match '(group (* '1 '1 '1)) "abc") # -> @[@["a" "b" "c"]]
+
+(peg/match '(replace (capture 1) {"x" :ant "y" :bee}) "x") # -> @[:ant]
+(peg/match ~(replace (* '1 '1) ,(fn [x y] [y x])) "01") # -> @[["1" "0"]]
+(peg/match ~(/ '(to "=") @{"a" "apricot"}) "a=3") # -> @["apricot"]
+(peg/match ~(/ (* '(to ",") 1 '(to -1)) ,|{$0 $1}) "x,y") # -> @[{"x" "y"}]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -412,6 +412,8 @@ grammars simpler.
 (peg/match ~(replace (* '1 '1) ,(fn [x y] [y x])) "01") # -> @[["1" "0"]]
 (peg/match ~(/ '(to "=") @{"a" "apricot"}) "a=3") # -> @["apricot"]
 (peg/match ~(/ (* '(to ",") 1 '(to -1)) ,|{$0 $1}) "x,y") # -> @[{"x" "y"}]
+
+(peg/match ~(constant :smile) "whatever") # -> @[:smile]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -402,6 +402,9 @@ grammars simpler.
 (peg/match ''"x" "xy") # -> @["x"]
 (peg/match ~'"x" "xy") # -> @["x"]
 (peg/match '(* 1 (capture "b")) "ab") # -> @["b"]
+
+(peg/match '(* (capture "a" :x) 1 (backref :x)) "a;b") # -> @["a" "a"]
+(peg/match '(* (<- "a" :y) (-> :y)) "a;b") # -> @["a" "a"]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -426,6 +426,9 @@ grammars simpler.
 
 (peg/match ~(line) "0123") # -> @[1]
 (peg/match ~(* 2 (line)) "0\n1") # -> @[2]
+
+(peg/match ~(accumulate (* '1 1 '1 1 '1)) "c,a,t") # -> @["cat"]
+(peg/match ~(% (some (* 1 '(to ";") ";"))) "fee;fie;foe;") # -> @["eeieoe"]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -447,6 +447,9 @@ grammars simpler.
 (peg/match ~(* (only-tags (* (<- 1 :x) 1)) (backref :x)) "xy") # -> @["x"]
 
 (peg/match ~(nth 2 (* '1 '1 '1)) "abc") # -> @["c"]
+
+(peg/match ~(uint 1) "a") # -> @[97]
+(peg/match ~(uint 2) "\xFF\x7F") # -> @[32767]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -443,6 +443,8 @@ grammars simpler.
 (peg/match ~(error -1) "nah") # -> nil
 
 (peg/match ~(drop (capture 1)) "x") # -> @[]
+
+(peg/match ~(* (only-tags (* (<- 1 :x) 1)) (backref :x)) "xy") # -> @["x"]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -461,6 +461,10 @@ grammars simpler.
 (peg/match ~(int-be 1) "\x80") # -> @[-128]
 (peg/match ~(int-be 2) "\xFF\x7F") # -> @[-129]
 (peg/match ~(int-be 2) "\x7F\xFF") # -> @[32767]
+
+(peg/match '(number (range "09")) "8") # -> @[8]
+(peg/match '(number (some (range "07")) 8) "10") # -> @[8]
+(peg/match '(number (some (range "09" "AF")) 16) "FF") # -> @[255]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -429,6 +429,9 @@ grammars simpler.
 
 (peg/match ~(accumulate (* '1 1 '1 1 '1)) "c,a,t") # -> @["cat"]
 (peg/match ~(% (some (* 1 '(to ";") ";"))) "fee;fie;foe;") # -> @["eeieoe"]
+
+(peg/match ~(cmt '(to -1) ,keyword) "greetings") # -> @[:greetings]
+(peg/match ~(cmt (* '1 "=" '1) ,table) "x=1") # -> @[@{"x" "1"}]
 ```
 
 ## Grammars and recursion

--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -454,6 +454,9 @@ grammars simpler.
 (peg/match ~(uint-be 1) "a") # -> @[97]
 (peg/match ~(uint-be 2) "\xFF\x7F") # -> @[65407]
 (peg/match ~(uint-be 2) "\x7F\xFF") # -> @[32767]
+
+(peg/match ~(int 1) "\x80") # -> @[-128]
+(peg/match ~(int 2) "\xFF\x7F") # -> @[32767]
 ```
 
 ## Grammars and recursion


### PR DESCRIPTION
This is an attempt to partially address https://github.com/janet-lang/janet-lang.org/issues/341.

Examples for the following capture PEG specials have been added:

* `capture`, `<-`, `'`
* `backref`
* `group`
* `replace`, `/`
* `constant`
* `argument`
* `position`, `$`
* `column`
* `line`
* `accumulate`, `%`
* `cmt`
* `unref`
* `error`
* `drop`
* `only-tags`
* `nth`
* `uint`
* `uint-be`
* `int`
* `int-be`
* `number`
* `lenprefix`

**Update**: The examples should at least be "correct" as I've checked them with the script posted [here](https://github.com/janet-lang/janet-lang.org/issues/341#issuecomment-4371937255).