### PR TITLE
Replace lenprefix example with improved one

### DIFF
--- a/content/docs/peg.mdz
+++ b/content/docs/peg.mdz
@@ -541,7 +541,7 @@ grammars simpler.
 (peg/match '(number (some (range "09" "AF")) 16) "FF") # -> @[255]
 
 # length obtained from top of capture stack placed there via `number`
-(peg/match ~'(lenprefix (number (range "09")) 1) "2xy") # -> @["2xy"]
+(peg/match ~(lenprefix (number (range "09")) '1) "2xy") # -> @["x" "y"]
 ```
 
 ## Grammars and recursion


### PR DESCRIPTION
This PR is an attempt to replace / modify the recently added `lenprefix` example.

I think the one in this PR more clearly demonstrates how `lenprefix` might be used.