### PR TITLE
Update path to examples.janet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ To cope with some of Janet's symbols having names with characters that
 are not-so-friendly to certain filesystem and/or operating system
 combinations, an escaping scheme is used.
 
-For a given symbol, use the `content/api/examples.janet` script to
+For a given symbol, use the `content/examples.janet` script to
 generate an appropriate filename.  For example, for `array/new`,
 invoking:
 
 ```
-$ janet content/api/examples.janet array/new
+$ janet content/examples.janet array/new
 ```
 
 should give the output:


### PR DESCRIPTION
As part of #230, the `examples.janet` file got a new home (but there was a transporter issue and we ended up with a duplicate) and in #353 the old version had its bits recycled.

There are some instructions in the README about using `examples.janet` that were not updated though.

This PR is an attempt to have the new location of `examples.janet` reflected in the README.