### PR TITLE
Add examples for get

### DIFF
--- a/examples/get.janet
+++ b/examples/get.janet
@@ -1,0 +1,28 @@
+(get "hello" 2) # -> 108
+(get @"hello" 2) # -> 108
+(get 'hello 1) # -> 101
+(get :hello 1) # -> 101
+(get :hello 8) # -> nil
+(get :hello 8 11) # -> 11
+
+(get [:bill :ted] 1) # -> :ted
+(get @[:ant :bee] 0) # -> :ant
+(get @[:ant :bee] 2) # -> nil
+(get @[:ant :bee] 2 :fox) # -> :fox
+
+(get {:length 20 :width 30} :width) # -> 30
+(get @{:x 5 :y 12} :y) # -> 12
+(get @{:x 5 :y 12} :z) # -> nil
+(get @{:x 5 :y 12} :z -1) # -> -1
+
+(def fib (coro (yield :a) (yield :b)))
+(get fib 0) # -> nil
+(resume fib) # -> :a
+(get fib 0) # -> :a
+(get fib 0) # -> :a
+(get fib 1 :oops) # -> :oops
+(resume fib) # -> :b
+(get fib 0) # -> :b
+(resume fib) # -> nil
+(get fib 0) # -> nil
+


### PR DESCRIPTION
This PR adds some examples for `get`.

On a related note, there is [a PR at the janet repository](https://github.com/janet-lang/janet/pull/1791) for updating the docstrings for some functions including `get`.  The examples in this PR are meant to be consistent with the updates in the other PR.

I'm making individual PRs for examples to make the review process smoother.  I think doing it this way may have the following benefits:

* makes the per-PR review and discussion effort more manageable which may in turn encourage participation as well as better attention per-PR
* avoids delaying the adding of examples for some functions / macros due to discussions over other functions / macros
