### PR TITLE
Add examples for next

### DIFF
--- a/examples/next.janet
+++ b/examples/next.janet
@@ -1,0 +1,21 @@
+(next "hi") # -> 0
+(next "hi" 0) # -> 1
+(next "hi" 1) # -> nil
+(next @"hello" 2) # -> 3
+(next 'hello 3) # -> 4
+(next :hello 4) # -> nil
+
+(next [:bill :ted] 0) # -> 1
+(next @[:ant :bee] 0) # -> 1
+(next @[:ant :bee] 1) # -> nil
+
+(next {:length 20 :width 30}) # -> :length or :width
+(next @{:x 5 :y 12}) # -> :x or :y
+(next @{:x 5 :y 12} :x) # -> :y or nil
+(next @{:x 5 :y 12} :y) # -> :x or nil
+
+(def fib (coro (yield :a) (yield :b)))
+(next fib) # -> 0
+(next fib) # -> 0
+(next fib) # -> nil
+


### PR DESCRIPTION
This PR adds some examples for `next`.

On a related note, there is https://github.com/janet-lang/janet/pull/1791 for updating the docstrings for some functions including `next`. The examples in this PR are meant to be consistent with the updates in the other PR.