### PR TITLE
Add examples for sort

### DIFF
--- a/examples/sort.janet
+++ b/examples/sort.janet
@@ -1,0 +1,11 @@
+(def buf @"zyx")
+(sort buf) # -> @"xyz"
+buf # ->  @"xyz"
+(sort buf >) # -> @"zyx"
+buf # ->  @"zyx"
+
+(def arr @[2 1 0])
+(sort arr) # -> @[0 1 2]
+arr # -> @[0 1 2]
+(sort arr >) # -> @[2 1 0]
+arr # -> @[2 1 0]


### PR DESCRIPTION
This PR adds some examples for `sort`.

---

On a related note, I'm working on an alternate docstring for `sort` (which would change the parameter names a bit) as well:

```janet
(defn sort
  ``
  Sorts `x` in-place, and returns it. Uses quick-sort and is not a
  stable sort. If a `before?` comparator function is provided, sorts
  elements using that, otherwise uses `<`.

  `x` can be a buffer, array, or abstract type with suitable `get`,
  `put`, and `length` methods.
  ``
  [x &opt before?]
  (default before? <)
  (sort-help x 0 (- (length x) 1) before?))
```

I verified the bit about abstract types by selectively disabling the `get`, `put`, and `length` methods inside spork's `tarray`.

---

I'm ambivalent about making multiple separate docstring-related PRs to the janet repository so I've been trying to group them so that the changes in each batch are pretty similar.