### PR TITLE
Add more examples for each

### DIFF
--- a/examples/each.janet
+++ b/examples/each.janet
@@ -1,9 +1,25 @@
-# prints 12345
-(each x [1 2 3 4 5] (prin x)) # -> nil
+(def buf @"")
+(each b "hello" (buffer/push buf b)) # -> nil
+buf # -> @"hello"
 
 # prints 12345
 (each y @[1 2 3 4 5] (prin y)) # -> nil
 
+(def arr @[])
+(each [_ [a b]] [[:x [0 1]] [:y [-1 0]]]
+  (array/push arr b a)) # -> nil
+arr # -> @[1 0 0 -1]
+
 # prints values from struct in an unspecified order
 # 21 -or- 12
 (each x {:a 1 :b 2} (prin x)) # -> nil
+
+(def arr @[])
+(each [a b] @{:x [0 1] :y [-1 0]}
+  (array/push arr a b)) # -> nil
+(sort arr) # -> @[-1 0 0 1]
+
+(def tab @{})
+(each [k v] (coro (yield [0 1]) (yield [2 8]))
+  (put tab v k)) # -> nil
+tab # -> @{1 0 8 2}


### PR DESCRIPTION
This PR adds some more examples for `each` and removes an existing one [1].

While the existing examples demonstrate a common use case, they did not illustrate:

* use of destructuring
* use of fibers

---

[1] I removed one of the examples because it seemed mostly redundant.