### PR TITLE
Add more examples for filter

### DIFF
--- a/examples/filter.janet
+++ b/examples/filter.janet
@@ -1,7 +1,9 @@
-(filter pos? [1 2 3 0 -4 5 6]) # -> @[1 2 3 5 6]
+(filter |(< (chr "A") $) "foo01bar") # -> @[102 111 111 98 97 114]
+(string/from-bytes ;(filter |(< (chr "A") $) "foo01bar")) # -> "foobar"
 
+(filter pos? [1 2 3 0 -4 5 6]) # -> @[1 2 3 5 6]
 (filter |(> (length $) 3) ["hello" "goodbye" "hi"]) # -> @["hello" "goodbye"]
 
-(filter |(< (chr "A") $) "foo01bar") # -> @[102 111 111 98 97 114]
+(sort (filter int? {:a 1 :b 2.3 :c 3})) # -> @[1 3]
 
-(string/from-bytes ;(filter |(< (chr "A") $) "foo01bar")) # -> "foobar"
+(filter even? (coro (yield 1) (yield 2) (yield 8))) # -> @[2 8]


### PR DESCRIPTION
This PR adds some more examples for `filter` and modifies the ordering / grouping a bit.

The additional examples add demonstration of usage with a dictionary in one case and a fiber in another.

Grouping and ordering was done to be more consistent with what's been done recently in other examples, i.e.:

* bytes type
* indexed type
* dictionary type
* fiber

It might be worth considering a convention as it can aid in more efficient scanning of examples in many cases.