### PR TITLE
Add more examples for eachk

### DIFF
--- a/examples/eachk.janet
+++ b/examples/eachk.janet
@@ -1,13 +1,16 @@
-# keys for tuple/array are 0-based index
+(def arr @[])
+(def str "lol")
+(eachk i str (array/push arr [i (get str i)])) # -> nil
+arr # -> @[[0 108] [1 111] [2 108]]
+
+# keys for tuples / arrays are 0-based index
 # prints 0 1 2 3 4
 (eachk i [:a :b :c :d :e] (prin i " ")) # -> nil
 
-# prints 0 1 2 3 4
-(eachk i @["a" "b" "c" "d" "e"] (prin i " ")) # -> nil
-
-# prints keys in table/struct in an unspecified order
+# print keys in tables / structs in an unspecified order
 # prints :b :a
 (eachk k {:a 1 :b 2} (prinf "%v " k)) # -> nil
 
-# prints :foo :bar
-(eachk k @{:foo "A" :bar "B"} (prinf "%v " k)) # -> nil
+(def arr @[])
+(eachk [_ j] {[:a 0] :x [:b 1] :y} (array/push arr j)) # -> nil
+arr # -> @[0 1]


### PR DESCRIPTION
This PR adds some more examples for `eachk` and removes an existing one [1].

While the existing examples demonstrate a common use case, they did not illustrate use of destructuring, nor was there an example that used a bytes type.

---

[1] I removed one of the examples because it seemed mostly redundant.