### PR TITLE
Add more examples for eachp

### DIFF
--- a/examples/eachp.janet
+++ b/examples/eachp.janet
@@ -1,13 +1,15 @@
-# keys for tuple/array are 0-based index
+(def arr @[])
+(eachp p "hello" (array/push arr p)) # -> nil
+arr # ->   @[[0 104] [1 101] [2 108] [3 108] [4 111]]
+
+# keys for tuples / arrays are 0-based index
 # prints 0->:a 1->:b 2->:c 3->:d 4->:e
 (eachp [i x] [:a :b :c :d :e] (prinf "%v->%v " i x)) # -> nil
-
-# prints 0->"a" 1->"b" 2->"c" 3->"d" 4->"e"
-(eachp [i x] @["a" "b" "c" "d" "e"] (prinf "%v->%v " i x)) # -> nil
 
 # key, value from table/struct in an unspecified order
 # prints :b -> 2 :a -> 1
 (eachp [k v] {:a 1 :b 2} (prinf "%v -> %v " k v)) # -> nil
 
-# prints :foo -> "A" :bar -> "B"
-(eachp [k v] @{:foo "A" :bar "B"} (prinf "%v -> %v " k v)) # -> nil
+(def arr @[])
+(eachp [i [j k]] {0 [1 2] 7 [8 9]} (array/push arr [j i k])) # -> nil
+(sort arr) # -> @[[1 0 2] [8 7 9]]


### PR DESCRIPTION
This PR adds some more examples for `eachp` and removes some existing ones [1].

While the existing examples demonstrate a common use case, they did not illustrate use of destructuring, nor was there an example that used a bytes type.

[1] I removed two of the examples because they seemed mostly redundant.