### PR TITLE
Add more examples for accumulate

### DIFF
--- a/examples/accumulate.janet
+++ b/examples/accumulate.janet
@@ -1,8 +1,11 @@
-(reduce + 0 [1 2 3 4]) # -> 10
-(accumulate + 0 [1 2 3 4]) # -> @[1 3 6 10]
+(accumulate string "" ["D" "a" "n"]) # -> @["D" "Da" "Dan"]
 
-(reduce + 0 []) # -> 0
+(accumulate + 0 "xyz") # -> @[120 241 363]
+
+(accumulate + 0 [1 2 3]) # -> @[1 3 6]
+
 (accumulate + 0 []) # -> @[]
 
-(reduce string "" ["J" "a" "n" "e" "t"]) # -> "Janet"
-(accumulate string "" ["J" "a" "n" "e" "t"]) # -> @["J" "Ja" "Jan" "Jane" "Janet"]
+(accumulate * 1 {:a -1 :b 2 :c -3}) # -> @[2 -6 6]
+
+(accumulate + 0 (coro (yield 1) (yield 2) (yield 3))) # -> @[1 3 6]

--- a/examples/accumulate.janet
+++ b/examples/accumulate.janet
@@ -1,10 +1,10 @@
-(accumulate string "" ["D" "a" "n"]) # -> @["D" "Da" "Dan"]
-
 (accumulate + 0 "xyz") # -> @[120 241 363]
 
 (accumulate + 0 [1 2 3]) # -> @[1 3 6]
 
 (accumulate + 0 []) # -> @[]
+
+(accumulate string "" @["J" "a" "n"]) # -> @["J" "Ja" "Jan"]
 
 (accumulate * 1 {:a -1 :b 2 :c -3}) # -> @[2 -6 6]
 


### PR DESCRIPTION
This PR adds some more examples for `accumulate` and removes some existing ones.

The additions include uses with:

* bytes type (using `+` instead of `string`)
* dictionary
* fiber

Some existing examples were shortened.  I think it's easier to see in more environments and it takes slightly less time to comprehend without losing essential aspects of the original (except the reference to "Janet").

The original set of examples nicely showed comparison calls using `reduce`.  Due to feedback, I decided to remove the calls to `reduce`.  I think it's easy enough to look up `reduce`'s examples on the same page as well as type in relevant examples at `janet`'s repl for comparison.