### PR TITLE
Add more examples for accumulate2

### DIFF
--- a/examples/accumulate2
+++ b/examples/accumulate2
@@ -1,8 +1,0 @@
-(reduce2 + [1 2 3 4]) # -> 10
-(accumulate2 + [1 2 3 4]) # -> @[1 3 6 10]
-
-(reduce2 + []) # -> nil
-(accumulate2 + []) # -> @[]
-
-(reduce2 max [1 4 2 3 9 5]) # -> 9
-(accumulate2 max [1 4 2 3 9 5]) # -> @[1 4 4 4 9 9]

--- a/examples/accumulate2.janet
+++ b/examples/accumulate2.janet
@@ -1,0 +1,18 @@
+(reduce2 + "hi") # ->  209
+(accumulate2 + "hi") # -> @[104 209]
+
+(reduce2 - @"") # -> nil
+(accumulate2 - @"") # -> @[]
+
+(reduce2 + [1 2 3]) # -> 6
+(accumulate2 + [1 2 3]) # -> @[1 3 6]
+
+(reduce2 + []) # -> nil
+(accumulate2 + []) # -> @[]
+
+(reduce2 max [1 2 3 9 5]) # -> 9
+(accumulate2 max [1 2 3 9 5]) # -> @[1 2 3 9 9]
+
+(accumulate2 * {:a 1 :b 2 :c 4}) # -> @[2 8 8]
+
+(accumulate2 * (coro (yield 4) (yield 2) (yield 1))) # -> @[4 8 8]

--- a/examples/accumulate2.janet
+++ b/examples/accumulate2.janet
@@ -1,16 +1,11 @@
-(reduce2 + "hi") # ->  209
 (accumulate2 + "hi") # -> @[104 209]
 
-(reduce2 - @"") # -> nil
 (accumulate2 - @"") # -> @[]
 
-(reduce2 + [1 2 3]) # -> 6
 (accumulate2 + [1 2 3]) # -> @[1 3 6]
 
-(reduce2 + []) # -> nil
 (accumulate2 + []) # -> @[]
 
-(reduce2 max [1 2 3 9 5]) # -> 9
 (accumulate2 max [1 2 3 9 5]) # -> @[1 2 3 9 9]
 
 (accumulate2 * {:a 1 :b 2 :c 4}) # -> @[2 8 8]


### PR DESCRIPTION
This PR adds some more examples for `accumulate2` and modifies some existing ones.

The additions include uses with:

* bytes type
* dictionary
* fiber

Some existing examples were shortened. I think it's easier to see in more environments.

The original set of examples nicely showed comparison calls using `reduce2`. I did similarly for some of the earlier additions but not for the later dictionary and fiber examples.

Also, it turns out I had failed to detect that the [original PR adding the initial examples](https://github.com/janet-lang/janet-lang.org/pull/261) had a file named in `accumulate2` and not `accumulate2.janet` (missing file extension), so the examples weren't showing up on the core api page.  I renamed the file in this PR, so once merged, the examples should be visible.