### PR TITLE
Add another example for reverse

### DIFF
--- a/examples/reverse.janet
+++ b/examples/reverse.janet
@@ -1,3 +1,5 @@
-(reverse [1 2 3]) # -> @[3 2 1]
 (reverse "abcdef") # -> @"fedcba"
 
+(reverse [1 2 3]) # -> @[3 2 1]
+
+(reverse (coro (yield :ant) (yield :bee))) # -> @[:bee :ant]


### PR DESCRIPTION
This PR adds another example for `reverse` showing that fibers can be used.

The order of the examples was changed somewhat to follow what's been done in some other examples [1].

---

[1] Roughly the order of:

* bytes type
* indexed type
* dictionary
* fiber