### PR TITLE
Add more examples for all

### DIFF
--- a/examples/all.janet
+++ b/examples/all.janet
@@ -1,15 +1,16 @@
+(all |(< $ (chr "m")) "abc") # -> true
+
 (all pos? [1 2 3]) # -> true
 (all pos? [1 2 -3]) # -> false
+(all truthy? @[1 2 nil]) # -> false
+(all neg? @[]) # -> true
 
-(all pos? []) # -> true
-(all neg? []) # -> true
-
-(all truthy? [1 2 3]) # -> true
-(all truthy? [1 2 nil]) # -> false
-
-# multiple data structures can be handled
+# variadic
 (all (fn [x y] (pos? (* x y))) [-1 2] [-2 1]) # -> true
 
 # predicate may not be applied to all values (e.g. 43)
 (all |(neg? (+ $0 $1 $2)) [-2 2] [1 -8] [0 1 43]) # -> true
 
+(all even? {:a 2 :b 8 :c 20}) # -> true
+
+(all pos? (coro (yield 1) (yield 2))) # -> true


### PR DESCRIPTION
This PR adds some more examples for `all` and removes some existing ones.

The changes consist of:

* demonstrating use with a bytes type, dictionary, and fiber
* showing some edge cases
* removing some redundant examples

Also, a comment was modified to use the term "variadic" [1] which should align with an upcoming PR to modify the docstring.

---

[1] As a side-effect, the term "data structure" was removed as I think it could have resulted in unnecessary confusion here.