### PR TITLE
Add more examples for some

### DIFF
--- a/examples/some.janet
+++ b/examples/some.janet
@@ -1,18 +1,23 @@
+(some |(< (chr "a") $) @"bcd") # -> true
+
 # pos? yielded only falsey values, so nil returned
 (some pos? [math/-inf 0]) # -> nil
 
 # first truthy result encountered is returned
 (some (fn [x] (when (pos? x) x)) [1 0 -1]) # -> 1
 
-# input data structure is empty, so nil returned
+# input is empty, so nil returned
 (some pos? []) # -> nil
 
-# multiple data structures can be handled
+# variadic
 (some (fn [x y] (neg? (* x y))) [1 1] [1 -2]) # -> true
 
-# predicate not always called with all values (e.g. 0)
+# predicate not always called with all values (i.e. 0)
 (some |(zero? (* $0 $1 $2)) [1 2] [7 8] [-2 -1 0]) # -> nil
 
-# one of the input data structures was empty, so nil returned
+# one of the inputs was empty, so nil returned
 (some |(pos? (+ $0 $1 $2)) [1 2 3] [7 8 9] []) # -> nil
 
+(some neg? {:a -1 :b 1}) # -> true
+
+(some even? (coro (yield 1) (yield 3) (yield 8))) # -> true


### PR DESCRIPTION
This PR adds some more examples for `some` and modifies some existing comments.

Some of the changes are:

* demonstrating use with a bytes type, dictionary, and fiber
* modifying some comments [1]

---

[1] Several instances of the term "data structure" were removed following what we've been doing in other PRs.