### PR TITLE
Add more examples for map

### DIFF
--- a/examples/map.janet
+++ b/examples/map.janet
@@ -1,9 +1,15 @@
-# inc is applied to every value of the input data structure
+(map identity @"lol") # -> @[108 111 108]
+
+# inc is applied to every value of the input
 (map inc [7 8 9]) # -> @[8 9 10]
 
-# multiple data structures can be handled
+# variadic
 (map array [:x :y] [-1 1]) # -> @[@[:x -1] @[:y 1]]
 
-# result array has length of the shortest input data structure
+# result array has length of the shortest input
 (map |(pos? (+ ;$&)) [1 2 3] [-1 -2 -3] [0 1]) # -> @[false true]
 
+# value order for dictionaries is unspecified
+(sort (map math/abs {:a -1 :b -2})) # -> @[1 2]
+
+(map inc (coro (yield 7) (yield 8) (yield 9))) # -> @[8 9 10]


### PR DESCRIPTION
This PR adds some more examples for `map` and modifies some existing comments.

Some of the changes are:

* demonstrating uses with bytes type, dictionary, and fiber values
* modifying some comments
