### PR TITLE
Add more examples for sum

### DIFF
--- a/examples/sum.janet
+++ b/examples/sum.janet
@@ -1,9 +1,14 @@
-(sum []) # -> 0
-(sum @[1]) # -> 1
-(sum (range 100)) # -> 4950
-
-# Sum over bytes values [0-255] in a string
+# sum over bytes values [0-255] in a bytes type
 (sum "hello") # -> 532
+(sum @"") # -> 0
 
-# Sum over values in a table or struct
-(sum {:a 1 :b 2 :c 4}) # -> 7
+(sum @[1]) # -> 1
+(sum @[2 3 5 7 11 13 17 19]) # -> 77
+(sum (range 100)) # -> 4950
+(sum []) # -> 0
+
+# sum over values in a dictionary
+(sum {:a 1 :b 2 :c 3}) # -> 6
+(sum @{0 -1 1 0 2 1}) # -> 0
+
+(sum (coro (yield 1) (yield 2) (yield 3))) # -> 6


### PR DESCRIPTION
This PR adds some more examples for `sum` and modifies some existing comments and examples.

Some of the changes are:

* demonstrated uses with buffer, table, and fiber values
* tweaked some example values
* modified some comments for consistency with other examples
