### PR TITLE
Add more examples for product

### DIFF
--- a/examples/product.janet
+++ b/examples/product.janet
@@ -1,10 +1,14 @@
-(product []) # -> 1
-(product @[1 2 3]) # -> 6
-(product [0 1 2 3]) # -> 0
-(product (range 1 10)) # -> 362880
-
-# Product over byte values [0-255] in a string
+# product over byte values [0-255] in a bytes type
 (product "hello") # -> 13599570816
+(product @"") # -> 1
 
-# Product over values in a table or struct
-(product {:a 1 :b 2 :c 4}) # -> 8
+(product @[1 2 3]) # -> 6
+(product [2 3 5 7 11 13 17 19]) # -> 9699690
+(product (range 1 10)) # -> 362880
+(product []) # -> 1
+
+# product over values in a dictionary
+(product {:a 1 :b 2 :c 3}) # -> 6
+(product @{0 -1 1 0 2 1}) # -> 0
+
+(product (coro (yield 1) (yield 2) (yield 3))) # -> 6


### PR DESCRIPTION
This PR adds some more examples for `product` and modifies some existing comments and examples.

Some of the changes are:

* demonstrated uses with buffer, table, and fiber values
* tweaked some example values
* modified some comments for consistency with other examples
