### PR TITLE
Fix typo for until on spork/misc.mdz

### DIFF
--- a/content/spork/api/misc.mdz
+++ b/content/spork/api/misc.mdz
@@ -259,6 +259,7 @@ Recursive macro get. Similar to get-in, but keys are variadic argument.
 ```
 
 ## until
+
 Repeat the body while the condition is false.
 
 Equivalent to `(while (not cnd) ;body)`.


### PR DESCRIPTION
Currently on https://janet-lang.org/spork/api/misc.html the description bleeds into the title

<img width="537" height="262" alt="Screenshot_20260821_134525" src="https://github.com/user-attachments/assets/c061ac1c-4690-45f6-a89d-7429e68cd1a9" />

This fixes it
