### PR TITLE
Add examples for struct/with-proto

### DIFF
--- a/examples/struct_47with-proto.janet
+++ b/examples/struct_47with-proto.janet
@@ -1,0 +1,8 @@
+(def st (struct/with-proto {:b 2} :a 1))
+(struct/getproto st) # -> {:b 2}
+(get st :a) # -> 1
+
+# kvs are optional
+(def st (struct/with-proto {:b 2}))
+(struct/getproto st) # -> {:b 2}
+(length st) # -> 0


### PR DESCRIPTION
This PR adds some examples for `struct/with-proto`.