### PR TITLE
Improve comparisons page

### DIFF
--- a/content/docs/comparison.mdz
+++ b/content/docs/comparison.mdz
@@ -16,12 +16,18 @@ as follows: @code[(< a b)] will return true if a < b, and false otherwise.
 Similarly @code[(= a b)] will be true only if a == b.
 
 @codeblock[janet](```
-(= 3 3)          # true
-(< 1 3)          # true
-(>= :a :a)       # true
-(> "bar" "foo")  # false -- strings compare lexicographically
-(<= :bar :foo)   # true -- keywords compare lexicographically by keyword name
-(= nil nil)      # true -- nil always equal to itself and only itself
+(= 3 3) # -> true
+(< 1 3) # -> true
+(>= :a :a) # -> true
+
+# strings compare lexicographically
+(> "bar" "foo") # -> false
+
+# keywords compare lexicographically by keyword name
+(<= :bar :foo) # -> true
+
+# nil always equals itself and only itself
+(= nil nil) # -> true
 ```)
 
 More generally, each of these operators can take any number of arguments
@@ -31,30 +37,60 @@ implied by the operator.  So @code[(< 1 2 3)] returns true but
 since its (nonexistent) arguments do not violate the ordering.
 
 @codeblock[janet](```
-(= 1 1 1)  # true
-(< 1 3 5)  # true
-(>= 3 1 7) # false
-(> 1)      # true
+(= 1 1 1) # -> true
+(< 1 3 5) # -> true
+(>= 3 1 7) # -> false
+(> 1) # -> true
 ```)
 
-The primitive comparison operators provide a total ordering for all Janet
-types, but importantly, these operators compare values of different types in a
-way that the user might find surprising.  If two arguments of a primitive
-comparison are of different types, they will be ordered by Janet's internal
-type number.  This is not necessarily what the user needs, for example, when
-comparing Janet int/s64 types to Janet numbers.
+The primitive comparison operators provide a total ordering for all
+Janet types, but importantly, these operators compare values of
+different types in a way that the user might find surprising in at
+least two ways.
+
+First, if two arguments of a primitive comparison are of different
+types, they will be ordered by Janet's internal type number.  This is
+not necessarily what the user needs, for example, when comparing Janet
+int/s64 types to Janet numbers.
 
 @codeblock[janet](```
-# surprisingly evaluates to false:
-(= (int/s64 1) (int/u64 1))
-# surprisingly evaluates to true but this due to Janet internal type number
-# for int/u64 types being greater than the internal type number for numbers!
-(< 3 (int/u64 2))
+# evaluates to false
+(= (int/s64 1) (int/u64 1)) # -> false
+
+# evaluates to true but this is due to the Janet internal type number
+# for int/u64 types being greater than the internal type number for
+# numbers!
+(< 3 (int/u64 2)) # -> true
 ```)
 
 If you require comparison between types to be ordered by something other than
 type number (e.g. "numeric value") then, use the polymorphic comparison
 operators, described below.
+
+Secondly, @code[=] does not compare the contents of buffers, arrays,
+tables, fibers, and some abstract types.  Instead, it checks if the
+two values are the same object.
+
+@codeblock[janet](```
+# even though these have the same content they are NOT considered =
+(= @"abc" @"abc") # -> false
+(= @{:a 1} @{:a 1}) # -> false
+(= @[:a :b] @[:a :b]) # -> false
+
+# = returns true for the same value
+(def x @{:a 1})
+(= x x) # -> true
+
+# = works as expected on immutable values
+(= nil nil) # -> true
+(= true true) # -> true
+(= 1 1) # -> true
+(= 'sym 'sym) # -> true
+(= :kwd :kwd) # -> true
+(= "abc" "abc") # -> true
+(= [:a :b] [:a :b]) # -> true
+(= {:a 1} {:a 1}) # -> true
+```)
 
 ## Polymorphic Comparison Operators
 
@@ -69,19 +105,30 @@ The polymorphic comparison operators are @code[compare=], @code[compare<],
 similarly to the primitive operators:
 
 @codeblock[janet](```
-(compare< 1 3)          # true
-(compare> "bar" "foo")  # false -- strings compare lexicographically
-(compare<= :bar :foo)   # true -- keywords compare lexicographically by keyword name
-(compare= nil nil)      # true -- nil always equal to itself and only itself
-(compare< 1 2 3)        # true -- just like <
+(compare< 1 3) # -> true
+
+# strings compare lexicographically
+(compare> "bar" "foo") # -> false
+
+# keywords compare lexicographically by keyword name
+(compare<= :bar :foo) # -> true
+
+# nil always equals itself and only itself
+(compare= nil nil) # -> true
+
+# just like <
+(compare< 1 2 3) # -> true
 ```)
 
 However, when comparing between int/s64, int/u64, and number types, these operators
 will "do the right thing".
 
 @codeblock[janet](```
-(compare= (int/s64 1) (int/u64 1))  # true -- they are "semantically" equal
-(compare< 3 (int/u64 2))            # false -- semantically 3 is not < 2
+# they are "semantically" equal
+(compare= (int/s64 1) (int/u64 1)) # -> true
+
+# semantically 3 is not < 2
+(compare< 3 (int/u64 2)) # -> false
 ```)
 
 In general the polymorphic operators are slower than the primitive ones, so
@@ -89,7 +136,7 @@ use the primitive ones unless you need the extra polymorphic features.
 
 ## Implementing Polymorphic Comparison
 
-If you just want to use the polymorphic comparison for the built in types, you
+If you just want to use the polymorphic comparison for the built-in types, you
 can skip this section, which is about how to implement polymorphic comparison
 for your own types.
 
@@ -106,8 +153,9 @@ function is as follows:
   @li{if @code`b` implements @code[:compare] and @code[(:compare b a)] is not nil, then return @code[(- (:compare b a))]}
   @li{else return @code[(cond (< a b) -1 (= a b) 0 1)]}}
 
-Since compare defers to the primitive operators as a last resort, the
-polymorphic comparison operators produce a total ordering of Janet types.
+Since @code`compare` defers to the primitive operators as a last
+resort, the polymorphic comparison operators produce a total ordering
+of Janet types.
 
 The compare method on an abstract type can be implemented in C, and the compare
 method for a table-based "object" can be implemented in Janet.  For more
@@ -117,38 +165,19 @@ section] for more information on developing object oriented methods on tables.
 
 ## Deep Equality Operator
 
-The primitive @code[=] operator does not compare the contents of mutable structures (arrays, tables, and buffers).
-Instead, it checks if the two values are the same object.
+To compare the contents of mutable values, use the @code`deep=`
+function.  This function compares buffers like strings, and
+recursively compares arrays and tables.
 
 @codeblock[janet](```
-# Even though they have the same contents these are considered *not* equal
-(assert (not= @{:a 1} @{:a 1}))
-(assert (not= @[:a :b] @[:a :b]))
-(assert (not= @"abc" @"abc"))
+(deep= [:a :b] [:a :b]) # -> true
+(deep= {:a 1} {:a 1}) # -> true
+(deep= "abc" "abc") # -> true
 
-# primitive equal will return true if they are same object
-(let [x @{:a 1}]
-  (assert (= x x)))
+(deep= @{:x @[@{:a 1} 3 @"hi"] :y 2}
+       @{:x @[@{:a 1} 3 @"hi"] :y 2}) # -> true
 
-# NOTE: = works as expected on immutable structures
-(assert (= [:a :b] [:a :b]))
-(assert (= {:a 1} {:a 1}))
-(assert (= "abc" "abc"))
-```)
-
-
-To compare the contents of mutable structures use the @code`deep=` function.
-This function compares buffers like strings, and recursively compares arrays and tables.
-
-@codeblock[janet](```
-(assert (deep= [:a :b] [:a :b]))
-(assert (deep= {:a 1} {:a 1}))
-(assert (deep= "abc" "abc"))
-
-(assert (deep=
-  @{ :x @[@{:a 1} 3 @"hi"] :y 2 }
-  @{ :x @[@{:a 1} 3 @"hi"] :y 2 }))
-
-# NOTE deep= uses primitive = when the values are not an array, table or buffer.
-(assert (deep-not= @{ :x (int/s64 1) } @{ :x (int/u64 1) }))
+# deep= uses = for immutable values
+(deep= @{:x (int/s64 1)}
+       @{:x (int/u64 1)}) # -> false
 ```)


### PR DESCRIPTION
This PR is an attempt to address #366.

The main suggested change is to gather together the two "surprising" characteristics of how `=` compares types.

Some additional changes include:

* Spell out a bit more about how `=` behaves.  Specifically, add mention of fibers and some abstract types and fill out corresponding examples a bit.
* Replace uses of `assert` with the `# -> <return value>` style of annotating evaluation results to align with most of the rest of the website prose.
* Modify some examples to not use `not=` and `deep-not=` [1] and use instead `=` and `deep=`.

---

[1] Although all instances of `not=` and `deep-not=` were removed from examples, these were not described in the prose originally (nor in the code comments), so it seemed acceptable to do.