### PR TITLE
Modify first section of data structures page

### DIFF
--- a/content/docs/data_structures/index.mdz
+++ b/content/docs/data_structures/index.mdz
@@ -3,12 +3,13 @@
  :order 11}
 ---
 
-Once you have a handle on functions and the primitive value types, you may be
-wondering how to work with collections of things. Janet has a small number of
-core data structure types that are very versatile. Tables, structs, arrays,
-tuples, strings, and buffers, are the 6 main built-in data structure types.
-These data structures can be arranged in a useful table describing their
-relationship to each other.
+Once you have a handle on functions and the primitive value types, you
+may be wondering how to work with collections of things.  Janet has a
+small number of core data structure types that are very versatile.
+Arrays, tuples, tables, structs, buffers, and strings (as well as
+symbols and keywords) are the main built-in data structure types.
+These data structures can be arranged in a useful table describing
+their relationship to each other.
 
 @tag[table]{
     @tr{@th{Interface} @th{Mutable} @th{Immutable}}
@@ -16,108 +17,122 @@ relationship to each other.
     @tr{@td{Dictionary} @td{Table} @td{Struct}}
     @tr{@td{Bytes} @td{Buffer} @td{String (Symbol, Keyword)}}}
 
-Indexed types are linear lists of elements than can be accessed in constant time
-with an integer index.  Indexed types are backed by a single chunk of memory for
-fast access, and are indexed from 0 as in C.  Dictionary types associate keys
-with values. The difference between dictionaries and indexed types is that
-dictionaries are not limited to integer keys. They are backed by a hash table
-and also offer constant time lookup (and insertion for the mutable case).
-Finally, the 'bytes' abstraction is any type that contains a sequence of bytes.
-A 'bytes' value or byteseq associates integer keys (the indices) with integer
-values between 0 and 255 (the byte values). In this way, they behave much like
-arrays and tuples. However, one cannot put non-integer values into a byteseq.
+Indexed types are linear lists of elements than can be accessed in
+constant time via an integer index.  Indexed types are backed by a
+single chunk of memory for fast access, and are indexed from 0 as in
+C.
 
-The table below summarizes the big-O complexity of various operations and other
-information on the built-in data structures. All primitive operations on data
-structures will run in constant time regardless of the number of items in the
-data structure.
+Dictionary types associate keys with values.  The difference between
+dictionaries and indexed types is that dictionaries are not limited to
+integer keys.  They are backed by a hash table and also offer constant
+time lookup (and insertion for the mutable case).
+
+Finally, the bytes type or byte sequence is a type that contains a
+sequence of bytes.  A bytes value or byteseq associates integer keys
+(the indices) with integer values between 0 and 255 (the byte values).
+In this way, they behave much like arrays and tuples.  However, one
+cannot put non-integer values into a byteseq.
+
+The table below summarizes the big-O complexity of various operations
+and other information of the built-in data structures.  All primitive
+operations on data structures will run in constant time regardless of
+the number of items in the data structure.
 
 @tag[table]{
-    @tr{@th{Data Structure} @th{Access} @th{Insert/Append} @th{Delete} @th{Space Complexity} @th{Mutable}}
-    @tr{@td{Array *} @td{O(1)} @td{O(1)} @td{O(1)} @td{O(n)} @td{Yes}}
-    @tr{@td{Tuple} @td{O(1)} @td{-} @td{-} @td{O(n)} @td{No}}
-    @tr{@td{Table} @td{O(1)} @td{O(1)} @td{O(1)} @td{O(n)} @td{Yes}}
-    @tr{@td{Struct} @td{O(1)} @td{-} @td{-} @td{O(n)} @td{No}}
-    @tr{@td{Buffer} @td{O(1)} @td{O(1)} @td{O(1)} @td{O(n)} @td{Yes}}
-    @tr{@td{String/Keyword/Symbol} @td{-} @td{-} @td{-} @td{O(n)} @td{No}}}
+  @tr{@th{Data Structure} @th{Access} @th{Insert/Append} @th{Delete} @th{Space Complexity} @th{Mutable}}
+  @tr{@td{Array *} @td{O(1)} @td{O(1)} @td{O(1)} @td{O(n)} @td{Yes}}
+  @tr{@td{Tuple} @td{O(1)} @td{-} @td{-} @td{O(n)} @td{No}}
+  @tr{@td{Table} @td{O(1)} @td{O(1)} @td{O(1)} @td{O(n)} @td{Yes}}
+  @tr{@td{Struct} @td{O(1)} @td{-} @td{-} @td{O(n)} @td{No}}
+  @tr{@td{Buffer} @td{O(1)} @td{O(1)} @td{O(1)} @td{O(n)} @td{Yes}}
+  @tr{@td{String/Keyword/Symbol} @td{-} @td{-} @td{-} @td{O(n)} @td{No}}}
 }
 
 *: Append and delete for an array correspond to @code[array/push] and
-@code[array/pop]. Removing or inserting elements at random indices will run in
-@code[O(n)] time where @code[n] is the number of elements in the array.
+@code[array/pop].  Removing or inserting elements at an arbitrary
+index will run in @code[O(n)] time where @code[n] is the number of
+elements in the array.
 
 @codeblock[janet](```
-(def my-tuple (tuple 1 2 3))
+(def my-tuple [1 2 3])
+(def another-tuple (tuple 1 2 3))
 
-(def my-array @(1 2 3))
-(def my-array (array 1 2 3))
+(def my-array @[1 2 3])
+(def another-array (array 1 2 3))
 
-(def my-struct {
- :key "value"
- :key2 "another"
- 1 2
- 4 3})
+(def my-struct
+  {:key "value"
+   :key2 "another"
+   1 2
+   4 3})
+(def another-struct (struct :a 1 :b 2))
 
-(def another-struct
- (struct :a 1 :b 2))
-
-(def my-table @{
- :a :b
- :c :d
- :A :qwerty})
-(def another-table
- (table 1 2 3 4))
+(def my-table
+  @{:a :b
+    :c :d
+    :A :qwerty})
+(def another-table (table 1 2 3 4))
 
 (def my-buffer @"thisismutable")
 (def my-buffer2 @``This is also mutable``)
 ```)
 
-To read the values in a data structure, use the @code`get` or @code`in` functions.
-The first
-parameter is the data structure itself, and the second parameter is the key. An
-optional third parameter can be used to specify a default if the value is not
-found.
+To read the values in a data structure, use the @code`get` or
+@code`in` functions.  The first parameter is the data structure
+itself, and the second parameter is the key.  An optional third
+parameter can be used to specify a default if the value is not found.
 
 @codeblock[janet]```
-(get @{:a 1} :a) # -> 1
-(get {:a 1} :a)  # -> 1
-(in  {:a 1} :a)  # -> 1
 (get @[:a :b :c] 2) # -> :c
-(in  @[:a :b :c] 2) # -> :c
+(in @[:a :b :c] 2) # -> :c
+
 (get (tuple "a" "b" "c") 1) # -> "b"
-(get @"hello, world" 1) # -> 101
-(get "hello, world" 1)  # -> 101
-(in  "hello, world" 1)  # -> 101
-(get {:a :b} :a)    # -> :b
+
+(get @{:a 1} :a) # -> 1
+(get {:a 1} :a) # -> 1
+(in {:a 1} :a) # -> 1
+
+# default values returned as :c was not found
 (get {:a :b} :c :d) # -> :d
-(in  {:a :b} :c :d) # -> :d
+(in {:a :b} :c :d) # -> :d
+
+(get @"hello, world" 1) # -> 101
+(get "hello, world" 1) # -> 101
+(in "hello, world" 1) # -> 101
 ```
 
-The @code`in` function (added in v1.5.0) for tables and structs behaves
-identically to @code`get`. However, the @code`in` function for arrays, tuples,
-and string-likes will throw errors on bad keys --- so to better detect errors,
-prefer @code`in` for these.
+The @code`in` function (added in v1.5.0) for tables and structs
+behaves identically to @code`get`.  However, for indexed and bytes
+types, the @code`in` function will throw errors on bad keys, so to
+better detect errors, prefer @code`in` for these.
 
 @codeblock[janet]```
+# nil returned as the key was not found
 (get @[:a :b :c] 3) # -> nil
-(in  @[:a :b :c] 3) # -> raises error
+
+# errors since the key is out of bounds (> 2)
+(in @[:a :b :c] 3)
 ```
 
-To update a mutable data structure, use the @code[put] function. It
+To update a mutable data structure, use the @code[put] function.  It
 takes 3 arguments, the data structure, the key, and the value, and
-returns the data structure. The allowed types of keys and values
+returns the data structure.  The allowed types of keys and values
 depend on the data structure passed in.
 
 @codeblock[janet]```
-(put @[] 100 :a)
-(put @{} :key "value")
-(put @"" 100 92)
+(put @[] 3 :a) # -> @[nil nil nil :a]
+
+(put @{} :key "value") # -> @{:key "value"}
+
+(put @"" 3 97) # -> @"\0\0\0a"
 ```
 
-Note that for arrays and buffers, putting an index that is outside the length of
-the data structure will extend the data structure and fill it with @code`nil`s
-in the case of the array, or @code`0`s in the case of the buffer.
+Note that for arrays and buffers, putting an index that is outside the
+length of the data structure will extend the data structure and fill
+it with @code`nil`s in the case of an array, or @code`0`s in the case
+of a buffer.
 
-The last generic function for all data structures is the @code[length] function.
-This returns the number of values in a data structure (the number of keys in a
-dictionary type).
+The last generic function for all data structures is the @code[length]
+function.  It returns the number of values in a data structure.  In
+the case of a dictionary type, this is also the same as the number of
+keys.


### PR DESCRIPTION
This PR contains some tweaking of the data structures index page that came about while working on #436 to add a copying section.

It includes:

* Consistency, spacing, ordering, and commenting tweaks to some of the code examples
* Order changes to certain things (e.g. placing indexed types before dictionary types) for consistency
* Some rewording
* Whitespace and reflow changes

I don't think it intersects with #436, but if this is going to be merged, it might be better to do so after #436 is (assuming that one gets merged).