### PR TITLE
Make example code more readable in more contexts

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -63,7 +63,7 @@ body {
 }
 
 @media (max-width: 1000px) {
-    .content-wrapper {
+    .mendoza-codeblock {
         max-width: 80ch;
     }
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -64,7 +64,7 @@ body {
 
 @media (max-width: 1000px) {
     .content-wrapper {
-        max-width: 600px;
+        max-width: 80ch;
     }
 }
 


### PR DESCRIPTION
For background, please see the discussion including and following [this message](https://janet.zulipchat.com/#narrow/channel/399615-general/topic/Janet.20Documentation.20Improvements/near/621246362).

The short of it is that currently, code examples can have undesirable line-wrapping (more often?) like this:

<img width="528" height="380" alt="before" src="https://github.com/user-attachments/assets/76d4d2f4-1e08-4190-bae9-f259bcf6a965" />

With the change in this PR, it can look more like this (more often):

<img width="699" height="358" alt="after" src="https://github.com/user-attachments/assets/43bcc4ef-67b3-4f55-9c83-c7b14d91f3bf" />

I think the relevant lines in [`main.css`](https://github.com/janet-lang/janet-lang.org/blob/8dcefbc49f06679fd08bfed447f782935e3f0aca/static/css/main.css) are:

```css
@media (max-width: 1000px) {
    .content-wrapper {
        max-width: 600px;
    }
}
```

IIUC, what's happening is that when the viewport (roughly, the browser window in most circumstances?) is less than 1000 pixels, the maximum width of things with the class `content-wrapper` is limited to 600 pixels and this can lead to undesirable line-wrapping.

I tried just disabling the `max-width`, but @brendanhowell had what seems like a better suggestion to use the CSS "ch" unit to specify 80 characters...which I think amounts to:

```css
@media (max-width: 1000px) {
    .content-wrapper {
        max-width: 80ch;
    }
}
```

So far, that's been working well for me for widths that are over 730 pixels or so.  Fewer pixels lead to line-wrapping here, but perhaps even for phones, if they are in landscape mode, enough of them can have an improved experience too?