### PR TITLE
Add example for thaw

### DIFF
--- a/examples/thaw.janet
+++ b/examples/thaw.janet
@@ -9,6 +9,16 @@
 (thaw {:a {:b 2}}) # -> @{:a @{:b 2}}
 (thaw @{[:x :y] [0 {:a "hi"}]}) # -> @{@[:x :y] @[0 @{:a @"hi"}]}
 
+(def key [:hi])
+(def value [0 {:a ["hi" 1]}])
+(def tab @{key value})
+(def thawed (thaw tab))
+(def new-key (first (keys thawed)))
+# dictionary keys changed too
+(tuple? key) # -> true
+(array? new-key) # -> true
+(deep= new-key (array ;key)) # -> true
+
 (thaw nil) # -> nil
 (thaw true) # -> true
 (thaw 2.71828) # -> 2.71828


### PR DESCRIPTION
This PR adds an example for `thaw` that demonstrates a resulting key being mutable.

It's intended to complement an example for `thaw-keep-keys` (in #441) that demonstrates a key being left alone in the return value.